### PR TITLE
[feat] health-swagger API 및 의존성 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/src/main/kotlin/com/stepbookstep/server/global/health/HealthController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/health/HealthController.kt
@@ -1,0 +1,18 @@
+package com.stepbookstep.server.global.health
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Health", description = "서버 상태 확인을 위한 헬스체크 API")
+@RestController
+class HealthController {
+
+    @Operation(summary = "서버 헬스 체크", description = "서버가 정상적으로 실행 중인지 확인합니다.")
+    @GetMapping("/health")
+    fun health(): ResponseEntity<Map<String, String>> {
+        return ResponseEntity.ok(mapOf("status" to "UP"))
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
@@ -1,0 +1,32 @@
+package com.stepbookstep.server.security.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .formLogin { it.disable() }
+            .httpBasic { it.disable() }
+            .authorizeHttpRequests { auth ->
+                auth.requestMatchers(
+                    "/health",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**"
+                ).permitAll()
+
+                // **우선 전부 허용**
+                auth.anyRequest().permitAll()
+            }
+
+        return http.build()
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 서버 헬스체크 확인을 위한 /health 엔드포인트를 추가했습니다.
- API 문서 확인을 위해 Swagger(OpenAPI)를 프로젝트에 적용했습니다. (코드 기동을 위해 의존성 코드 한줄 추가되었습니다.)
- 개발 환경에서 Swagger/Health 접근을 허용하는 SecurityConfig를 추가했습니다.


## 🔍 참고 사항
- 해당 설정은 CI/CD 배포 시 서버 기동 여부 및 API 문서 확인 용도의 선행 작업입니다.
- 로컬에서 빌드 및 테스트 확인했습니다. 

## 🖼️ 스크린샷
- 로컬에서의 테스트 화면
<img width="1243" height="624" alt="스크린샷 2026-01-08 오후 7 17 40" src="https://github.com/user-attachments/assets/cc5fca69-1cfa-44e0-98f6-815923703729" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인