### PR TITLE
[fix] CI/CD 타임아웃 개선 및 안정성 강화

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -92,6 +92,7 @@ jobs:
           host: ${{ secrets.EC2_PUBLIC_IP }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
+          command_timeout: 15m
           script: |
             cd /home/ubuntu/stepbookstep-dev/docker/
             docker pull ${{ secrets.DOCKER_USERNAME }}/server:latest

--- a/.github/workflows/prod-cicd.yml
+++ b/.github/workflows/prod-cicd.yml
@@ -80,8 +80,9 @@ jobs:
           host: ${{ secrets.EC2_PUBLIC_IP }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
+          command_timeout: 15m
           script: |
             cd /home/ubuntu/stepbookstep-prod/docker/
             docker pull ${{ secrets.DOCKER_USERNAME }}/server:prod-latest
-            docker compose -f docker-compose.prod.yml down
+            docker compose -f docker-compose.prod.yml down --timeout 60
             docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
dev, prod CICD 워크플로우 모두 command_timeout을 15m으로 증가했습니다.
prod에는 docker compose down에 --timeout 60을 추가하여 컨테이너 정상 종료 시간을 60초로 설정했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인