### PR TITLE
[feat] 홈 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
@@ -9,6 +9,7 @@ import java.time.LocalDateTime
     name = "books_new",
     indexes = [
         Index(name = "idx_isbn13", columnList = "isbn13", unique = true),
+        Index(name = "idx_origin", columnList = "origin"),
         Index(name = "idx_genre", columnList = "genre"),
         Index(name = "idx_published_date", columnList = "pub_date"),
         Index(name = "idx_pub_year", columnList = "pub_year"),
@@ -61,9 +62,11 @@ class Book(
     val weight: Int = 0,
 
     // ===== 서비스 고유 필드 =====
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
-    val genre: BookGenre,
+    val origin: String,
+
+    @Column(nullable = false, length = 50)
+    val genre: String,
 
     @Column(nullable = false)
     val level: Int = 1,
@@ -71,6 +74,9 @@ class Book(
     @Enumerated(EnumType.STRING)
     @Column(name = "vocab_level", nullable = false, length = 20)
     val vocabLevel: VocabLevel = VocabLevel.EASY,
+
+    @Column(name = "is_bestseller", nullable = false)
+    val isBestseller: Boolean = false,
 
     // ===== 시스템 필드 =====
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookGenre.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookGenre.kt
@@ -1,10 +1,24 @@
 package com.stepbookstep.server.domain.book.domain
 
-enum class BookGenre(val displayName: String) {
+enum class BookOrigin(val displayName: String) {
     KOREAN_NOVEL("한국소설"),
     JAPANESE_NOVEL("일본소설"),
     CHINESE_NOVEL("중국소설"),
     ENGLISH_NOVEL("영미소설"),
     FRENCH_NOVEL("프랑스소설"),
     GERMAN_NOVEL("독일소설")
+}
+
+enum class BookGenre(val displayName: String) {
+    MYSTERY("추리/미스터리"),
+    LIGHT_NOVEL("라이트 노벨"),
+    FANTASY("판타지/환상문학"),
+    HISTORICAL("역사소설"),
+    SF("과학소설(SF)"),
+    HORROR("호러/공포소설"),
+    MARTIAL_ARTS("무협소설"),
+    ACTION_THRILLER("액션/스릴러"),
+    ROMANCE("로맨스"),
+    POETRY("시"),
+    DRAMA("희곡")
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
@@ -19,4 +19,22 @@ interface BookRepository : JpaRepository<Book, Long> {
         WHERE b.title LIKE %:keyword% OR b.author LIKE %:keyword% OR b.publisher LIKE %:keyword%
     """)
     fun searchByKeyword(@Param("keyword") keyword: String): List<Book>
+
+    @Query(
+        value = "SELECT * FROM books_new WHERE genre = :genre ORDER BY RAND() LIMIT 10",
+        nativeQuery = true
+    )
+    fun findRandomByGenre(@Param("genre") genre: String): List<Book>
+
+    @Query(
+        value = "SELECT * FROM books_new WHERE item_page < 200 ORDER BY RAND() LIMIT 10",
+        nativeQuery = true
+    )
+    fun findUnder200Pages(): List<Book>
+
+    @Query(
+        value = "SELECT * FROM books_new WHERE is_bestseller = 1 ORDER BY RAND() LIMIT 10",
+        nativeQuery = true
+    )
+    fun findBestsellers(): List<Book>
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
@@ -21,19 +21,19 @@ interface BookRepository : JpaRepository<Book, Long> {
     fun searchByKeyword(@Param("keyword") keyword: String): List<Book>
 
     @Query(
-        value = "SELECT * FROM books_new WHERE genre = :genre ORDER BY RAND() LIMIT 10",
+        value = "SELECT * FROM books_new WHERE genre = :genre ORDER BY RAND() LIMIT 20",
         nativeQuery = true
     )
     fun findRandomByGenre(@Param("genre") genre: String): List<Book>
 
     @Query(
-        value = "SELECT * FROM books_new WHERE item_page < 200 ORDER BY RAND() LIMIT 10",
+        value = "SELECT * FROM books_new WHERE item_page < 200 ORDER BY RAND() LIMIT 20",
         nativeQuery = true
     )
     fun findUnder200Pages(): List<Book>
 
     @Query(
-        value = "SELECT * FROM books_new WHERE is_bestseller = 1 ORDER BY RAND() LIMIT 10",
+        value = "SELECT * FROM books_new WHERE is_bestseller = 1 ORDER BY RAND() LIMIT 20",
         nativeQuery = true
     )
     fun findBestsellers(): List<Book>

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookDetailResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookDetailResponse.kt
@@ -54,7 +54,7 @@ data class BookInfo(
                 "Lv.${book.level}",
                 "#${book.itemPage}p",
                 "#${book.vocabLevel.toDisplayName()}",
-                "#${book.genre.displayName}"
+                "#${book.genre}"
             )
         }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
@@ -28,6 +28,7 @@ class HomeQueryService(
         return HomeResponse(
             genreBooks = GenreBooks.of(genre, genreBooks),
             recommendations = Recommendations.of(under200Books, bestsellerBooks)
+            // TODO: 독서 통계 부분은 추가 구현할 예정입니다.
         )
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
@@ -1,0 +1,33 @@
+package com.stepbookstep.server.domain.home.application
+
+import com.stepbookstep.server.domain.book.domain.BookGenre
+import com.stepbookstep.server.domain.book.domain.BookRepository
+import com.stepbookstep.server.domain.home.presentation.dto.GenreBooks
+import com.stepbookstep.server.domain.home.presentation.dto.HomeResponse
+import com.stepbookstep.server.domain.home.presentation.dto.Recommendations
+import com.stepbookstep.server.global.response.CustomException
+import com.stepbookstep.server.global.response.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class HomeQueryService(
+    private val bookRepository: BookRepository
+) {
+
+    fun getHome(genreId: Int?): HomeResponse {
+        val genre = genreId?.let {
+            BookGenre.entries.getOrNull(it) ?: throw CustomException(ErrorCode.INVALID_GENRE_ID)
+        } ?: BookGenre.entries.first()
+
+        val genreBooks = bookRepository.findRandomByGenre(genre.displayName)
+        val under200Books = bookRepository.findUnder200Pages()
+        val bestsellerBooks = bookRepository.findBestsellers()
+
+        return HomeResponse(
+            genreBooks = GenreBooks.of(genre, genreBooks),
+            recommendations = Recommendations.of(under200Books, bestsellerBooks)
+        )
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/HomeController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/HomeController.kt
@@ -1,0 +1,34 @@
+package com.stepbookstep.server.domain.home.presentation
+
+import com.stepbookstep.server.domain.home.application.HomeQueryService
+import com.stepbookstep.server.domain.home.presentation.dto.HomeResponse
+import com.stepbookstep.server.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Home", description = "홈 화면 API")
+@RestController
+@RequestMapping("/api/v1/home")
+class HomeController(
+    private val homeQueryService: HomeQueryService
+) {
+
+    @Operation(summary = "홈 목록 조회", description = "홈 화면에 필요한 모든 데이터를 조회합니다.")
+    @GetMapping
+    fun getHome(
+        // TODO: 온보딩 API 구현 후, JWT에서 사용자 ID 추출 → User 테이블의 선호 장르 조회로 변경 예정
+        @Parameter(
+            description = "장르 ID (0: 추리/미스터리, 1: 라이트 노벨, 2: 판타지/환상문학, 3: 역사소설, 4: 과학소설(SF), 5: 호러/공포소설, 6: 무협소설, 7: 액션/스릴러, 8: 로맨스, 9: 시, 10: 희곡)"
+        )
+        @RequestParam(required = false) genreId: Int?
+    ): ResponseEntity<ApiResponse<HomeResponse>> {
+        val response = homeQueryService.getHome(genreId)
+        return ResponseEntity.ok(ApiResponse.ok(response))
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/HomeController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/HomeController.kt
@@ -19,7 +19,24 @@ class HomeController(
     private val homeQueryService: HomeQueryService
 ) {
 
-    @Operation(summary = "홈 목록 조회", description = "홈 화면에 필요한 모든 데이터를 조회합니다.")
+    @Operation(
+        summary = "홈 목록 조회",
+        description = """
+            홈 화면에 필요한 모든 데이터를 한 번에 조회합니다.
+
+            ## 응답 구조
+            - **genreBooks**: 선택한 장르의 도서 목록 (최대 20권)
+            - **recommendations**: 오늘의 추천 도서 (3가지 카테고리)
+              - under200: 200쪽 미만 도서
+              - levelUp: 레벨업 도전 도서
+              - bestseller: 베스트셀러 도서
+
+            ## 프론트엔드 사용 가이드
+            recommendations의 3가지 리스트는 한 번에 전달되며,
+            탭/버튼 클릭 시 해당 배열만 렌더링하면 됩니다.
+            (추가 API 호출 불필요)
+        """
+    )
     @GetMapping
     fun getHome(
         // TODO: 온보딩 API 구현 후, JWT에서 사용자 ID 추출 → User 테이블의 선호 장르 조회로 변경 예정

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/dto/HomeResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/dto/HomeResponse.kt
@@ -1,0 +1,61 @@
+package com.stepbookstep.server.domain.home.presentation.dto
+
+import com.stepbookstep.server.domain.book.domain.Book
+import com.stepbookstep.server.domain.book.domain.BookGenre
+
+data class HomeResponse(
+    val genreBooks: GenreBooks,
+    val recommendations: Recommendations
+    // TODO: 독서 통계 섹션 - 독서 기록 API 연동 후 추가 예정
+)
+
+data class GenreBooks(
+    val genre: String,
+    val genreId: Int,
+    val books: List<BookItem>
+) {
+    companion object {
+        fun of(genre: BookGenre, books: List<Book>): GenreBooks {
+            return GenreBooks(
+                genre = genre.displayName,
+                genreId = genre.ordinal,
+                books = books.map { BookItem.from(it) }
+            )
+        }
+    }
+}
+
+data class Recommendations(
+    val under200: List<BookItem>,
+    val levelUp: List<BookItem>,
+    val bestseller: List<BookItem>
+) {
+    companion object {
+        fun of(
+            under200Books: List<Book>,
+            bestsellerBooks: List<Book>
+        ): Recommendations {
+            return Recommendations(
+                under200 = under200Books.map { BookItem.from(it) },
+                levelUp = emptyList(), // TODO: 레벨업 도전 도서 - API 연동 후 구현 예정
+                bestseller = bestsellerBooks.map { BookItem.from(it) }
+            )
+        }
+    }
+}
+
+data class BookItem(
+    val bookId: Long,
+    val title: String,
+    val coverImage: String
+) {
+    companion object {
+        fun from(book: Book): BookItem {
+            return BookItem(
+                bookId = book.id,
+                title = book.title,
+                coverImage = book.coverUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
@@ -105,6 +105,7 @@ enum class ErrorCode(
     // 2000~2999 : 책 관련 에러
     // ========================
     BOOK_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당하는 도서가 존재하지 않습니다."),
+    INVALID_GENRE_ID(2001, HttpStatus.BAD_REQUEST, "유효하지 않은 장르 ID입니다. (0~10)"),
 
 
     // ========================


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
홈 목록 조회 API(`GET /api/v1/home?categoryId=0` – `optional`)를 구현했습니다.
홈 화면에 필요한 데이터를 한 번의 요청으로 조회할 수 있도록
- 장르별 추천 도서
- 오늘의 추천 도서 (200쪽 미만/ 레벨업 도전/베스트셀러)
- 독서 통계 정보

를 포함한 응답 객체 구조를 설계·구현했습니다.
또한 홈 데이터 제공을 위해 장르 및 베스트셀러 크롤링 작업을 완료하고 DB에 적재했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
- 독서 통계, 레벨업 도서 부분은 API가 미완성인 상태이므로, TODO로 주석표시 해놓았습니다.
- 홈 화면에 노출되는 도서 목록은 최대 20권까지 랜덤으로 조회되도록 구현했습니다.
- 추후 온보딩 API 구현 이후, JWT에서 사용자 ID를 추출하여 User 테이블의 선호 장르를 기반으로 조회하도록 개선할 예정입니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
**- 홈 목록 조회**
<img width="1414" height="570" alt="image" src="https://github.com/user-attachments/assets/3a9a26c0-b250-4d9b-96a7-f270ca46aa08" />
**- 장르 도서**
<img width="1398" height="683" alt="image" src="https://github.com/user-attachments/assets/6a3458fc-5a52-49eb-a4d0-fbc0d0743ff8" />
**- 추천 도서** 
<img width="1402" height="487" alt="image" src="https://github.com/user-attachments/assets/328daeec-a387-4852-bf4b-0fe782b441cb" />
**- 베스트셀러(레벨업 도서는 빈리스트 반환)**
<img width="1402" height="490" alt="image" src="https://github.com/user-attachments/assets/95f99a62-d24b-49a7-8ff7-424568682cac" />

**- 유효하지 않은 장르 ID를 입력했을 시**
<img width="1409" height="434" alt="image" src="https://github.com/user-attachments/assets/c071f2ea-81a0-469c-9c65-4a3ea985f944" />


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#18 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인