### PR TITLE
[feat] 온보딩 API 구현

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/OnboardingRuleEngine.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/OnboardingRuleEngine.kt
@@ -1,0 +1,36 @@
+package com.stepbookstep.server.domain.onboarding.application
+
+import com.stepbookstep.server.domain.onboarding.application.dto.LevelAnswers
+import com.stepbookstep.server.domain.onboarding.domain.enum.*
+import org.springframework.stereotype.Component
+
+/**
+ * 온보딩 설문 응답(LevelAnswers)을 기반으로
+ * 사용자 독서 레벨과 추천 루틴 타입을 계산하는 규칙 엔진
+ */
+@Component
+class OnboardingRuleEngine {
+
+    data class Result(
+        val level: Int,
+        val routineType: RoutineType
+    )
+
+    fun calculate(a: LevelAnswers): Result {
+        // TODO: 규칙 확정되면 정교화 (현재는 임시로 고정값을 반환합니다.)
+        val level = when (a.readingFrequency) {
+            ReadingFrequencyAnswer.FINISHED_RECENTLY -> 3
+            ReadingFrequencyAnswer.STOP_MIDWAY -> 2
+            ReadingFrequencyAnswer.LONG_TIME_NO_BOOK,
+            ReadingFrequencyAnswer.DONT_KNOW_START -> 1
+        }
+
+        val routineType = when (level) {
+            3 -> RoutineType.HARD
+            2 -> RoutineType.NORMAL
+            else -> RoutineType.LIGHT
+        }
+
+        return Result(level, routineType)
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/UserOnboardingService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/UserOnboardingService.kt
@@ -1,0 +1,81 @@
+package com.stepbookstep.server.domain.onboarding.application
+
+import com.stepbookstep.server.domain.onboarding.application.dto.NicknameCheckResponse
+import com.stepbookstep.server.domain.onboarding.application.dto.OnboardingSaveRequest
+import com.stepbookstep.server.domain.onboarding.application.dto.OnboardingSaveResponse
+import com.stepbookstep.server.domain.user.domain.UserCategoryPreference
+import com.stepbookstep.server.domain.user.domain.UserCategoryPreferenceRepository
+import com.stepbookstep.server.domain.user.domain.UserRepository
+import com.stepbookstep.server.global.response.CustomException
+import com.stepbookstep.server.global.response.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 온보딩 저장
+ * - 닉네임 중복 확인
+ * - categoryIds 저장
+ * - 레벨/루틴 계산
+ * - User에 결과 반영
+ */
+
+@Service
+class UserOnboardingService(
+    private val userRepository: UserRepository,
+    private val userCategoryPreferenceRepository: UserCategoryPreferenceRepository,
+    private val ruleEngine: OnboardingRuleEngine
+) {
+    private val nicknameRegex = Regex("^[가-힣a-zA-Z0-9]{2,15}$")
+
+    fun checkNickname(nickname: String): NicknameCheckResponse {
+        val trimmed = nickname.trim()
+        validateNickname(trimmed)
+
+        return NicknameCheckResponse(
+            nickname = trimmed,
+            isAvailable = !userRepository.existsByNickname(trimmed)
+        )
+    }
+
+    @Transactional
+    fun saveOnboarding(userId: Long, request: OnboardingSaveRequest): OnboardingSaveResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { CustomException(ErrorCode.USER_NOT_FOUND) }
+
+        validateNickname(request.nickname)
+
+        if (userRepository.existsByNicknameAndIdNot(request.nickname, userId)) {
+            throw CustomException(ErrorCode.DUPLICATED_NICKNAME)
+        }
+
+        user.nickname = request.nickname
+        user.isOnboarded = true
+
+        userCategoryPreferenceRepository.deleteAllByUserId(userId)
+
+        val preferences = request.categoryIds.distinct().map { categoryId ->
+            UserCategoryPreference(userId = userId, categoryId = categoryId)
+        }
+        userCategoryPreferenceRepository.saveAll(preferences)
+
+        val result = ruleEngine.calculate(request.levelAnswers)
+
+        user.applyOnboardingResult(
+            nickname = request.nickname,
+            level = result.level,
+            routineType = result.routineType
+        )
+
+        return OnboardingSaveResponse(
+            isOnboarded = true,
+            level = result.level,
+            routineType = result.routineType
+        )
+    }
+
+    private fun validateNickname(nickname: String) {
+        if (!nicknameRegex.matches(nickname)) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/NicknameCheckResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/NicknameCheckResponse.kt
@@ -1,0 +1,6 @@
+package com.stepbookstep.server.domain.onboarding.application.dto
+
+data class NicknameCheckResponse(
+    val nickname: String,
+    val isAvailable: Boolean
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/OnboardingSaveRequest.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/OnboardingSaveRequest.kt
@@ -1,0 +1,23 @@
+package com.stepbookstep.server.domain.onboarding.application.dto
+
+import com.stepbookstep.server.domain.onboarding.domain.enum.*
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+data class OnboardingSaveRequest(
+    @field:NotBlank
+    val nickname: String,
+
+    @field:NotNull
+    val levelAnswers: LevelAnswers,
+
+    @field:NotEmpty
+    val categoryIds: List<Int>
+)
+
+data class LevelAnswers(
+    val readingFrequency: ReadingFrequencyAnswer,
+    val readingDuration: ReadingDurationAnswer,
+    val difficultyPreference: DifficultyPreferenceAnswer
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/OnboardingSaveResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/OnboardingSaveResponse.kt
@@ -1,0 +1,9 @@
+package com.stepbookstep.server.domain.onboarding.application.dto
+
+import com.stepbookstep.server.domain.onboarding.domain.enum.RoutineType
+
+data class OnboardingSaveResponse(
+    val isOnboarded: Boolean,
+    val level: Int,
+    val routineType: RoutineType
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/DifficultyPreferenceAnswer.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/DifficultyPreferenceAnswer.kt
@@ -1,0 +1,11 @@
+package com.stepbookstep.server.domain.onboarding.domain.enum
+
+/**
+ * 온보딩 레벨 측정을 위한 도서 선택 기준 질문 enum
+ */
+enum class DifficultyPreferenceAnswer {
+    THICK_OR_HARD_BOOK, // 두껍거나 어려워보이는 책 -> 얇은 책
+    HARD_TO_UNDERSTAND, // 무슨 말인지 잘 안 들어오는 문장 -> 장르 분류에서 선택하게 함
+    PRESSURE_TO_FINISH, //레벨 별 추천도서
+    NO_BURDEN // 레벨 별 추천도서
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingDurationAnswer.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingDurationAnswer.kt
@@ -1,0 +1,11 @@
+package com.stepbookstep.server.domain.onboarding.domain.enum
+
+/**
+ * 온보딩 레벨 측정을 위한 독서 시간 측정 질문 enum
+ */
+enum class ReadingDurationAnswer {
+    SHORT_CHUNKS, // 짧게 끊어 읽는 게 좋아요 -> 10분
+    ONE_CHAPTER, // 한 챕터 정도는 괜찮아요 -> 20쪽
+    READ_LONG_TIME, // 한 번 잡으면 꽤 오래 읽어요 -> 20분
+    IT_DEPENDS // 그때그때 달라요 -> 10분
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingFrequencyAnswer.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingFrequencyAnswer.kt
@@ -1,0 +1,11 @@
+package com.stepbookstep.server.domain.onboarding.domain.enum
+
+/**
+ * 온보딩 레벨 측정을 위한 독서 선호/빈도 측정 질문 enum
+ */
+enum class ReadingFrequencyAnswer {
+    FINISHED_RECENTLY, // 최근에도 책 한 권은 끝까지 읽었어요 -> 하루
+    STOP_MIDWAY, // 읽고 싶긴 한데, 자주 중간에 멈춰요 -> 하루
+    LONG_TIME_NO_BOOK, // 책을 펼치는 것 자체가 오랜만이에요 -> 일주일
+    DONT_KNOW_START // 솔직히 어디서부터 시작해야 할지 모르겠어요 -> 일주일
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/RoutineType.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/RoutineType.kt
@@ -1,0 +1,8 @@
+package com.stepbookstep.server.domain.onboarding.domain.enum
+
+/**
+ * 온보딩 레벨 측정을 통한 루틴 추천 -> 아직 구체화되지 X
+ */
+enum class RoutineType {
+    LIGHT, NORMAL, HARD
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/presentation/UserOnboardingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/presentation/UserOnboardingController.kt
@@ -1,0 +1,31 @@
+package com.stepbookstep.server.domain.onboarding.presentation
+
+import com.stepbookstep.server.domain.onboarding.application.UserOnboardingService
+import com.stepbookstep.server.domain.onboarding.application.dto.*
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Users", description = "사용자 온보딩/프로필 관련 API")
+@RestController
+@RequestMapping("/api/v1/users")
+class UserOnboardingController(
+    private val onboardingService: UserOnboardingService
+) {
+
+    @Operation(summary = "닉네임 중복 확인", description = "온보딩 첫 화면에서 입력한 닉네임이 사용 가능한지 확인합니다. - 형식: 한글/영문/숫자만, 2자 이상 15자 이하")
+    @GetMapping("/check")
+    fun checkNickname(@RequestParam nickname: String): ResponseEntity<NicknameCheckResponse> {
+        return ResponseEntity.ok(onboardingService.checkNickname(nickname))
+    }
+
+    @Operation(summary = "온보딩 정보 저장", description = "사용자의 온보딩 정보를 저장하고 가입 완료 상태로 변경합니다.")
+    @PostMapping("/onboarding")
+    fun saveOnboarding(
+        @RequestAttribute("userId") userId: Long,
+        @RequestBody request: OnboardingSaveRequest
+    ): ResponseEntity<OnboardingSaveResponse> {
+        return ResponseEntity.ok(onboardingService.saveOnboarding(userId, request))
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
@@ -1,7 +1,10 @@
 package com.stepbookstep.server.domain.user.domain
 
+import com.stepbookstep.server.domain.onboarding.domain.enum.RoutineType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -32,5 +35,28 @@ class User(
     val createdAt: OffsetDateTime = OffsetDateTime.now(),
 
     @Column(name = "updated_at", nullable = false)
-    var updatedAt: OffsetDateTime = OffsetDateTime.now()
-)
+    var updatedAt: OffsetDateTime = OffsetDateTime.now(),
+
+    // ===== 온보딩 결과 저장 =====
+    @Column(name = "level", nullable = false)
+    var level: Int = 1,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "routine_type", length = 20)
+    var routineType: RoutineType? = null,
+
+    @Column(name = "is_onboarded", nullable = false)
+    var isOnboarded: Boolean = false,
+) {
+    fun applyOnboardingResult(
+        nickname: String,
+        level: Int,
+        routineType: RoutineType
+    ) {
+        this.nickname = nickname
+        this.level = level
+        this.routineType = routineType
+        this.isOnboarded = true
+        this.updatedAt = OffsetDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserCategoryPreference.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserCategoryPreference.kt
@@ -1,0 +1,30 @@
+package com.stepbookstep.server.domain.user.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "user_category_preferences",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_user_category",
+            columnNames = ["user_id", "category_id"]
+        )
+    ]
+)
+class UserCategoryPreference(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(name = "category_id", nullable = false)
+    val categoryId: Int,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserCategoryPreferenceRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserCategoryPreferenceRepository.kt
@@ -1,0 +1,14 @@
+package com.stepbookstep.server.domain.user.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.transaction.annotation.Transactional
+
+interface UserCategoryPreferenceRepository : JpaRepository<UserCategoryPreference, Long> {
+
+    @Modifying
+    @Transactional
+    fun deleteAllByUserId(userId: Long)
+
+    fun existsByUserIdAndCategoryId(userId: Long, categoryId: Int): Boolean
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserRepository.kt
@@ -8,4 +8,6 @@ interface UserRepository : JpaRepository<User, Long> {
         provider: String,
         providerUserId: String
     ): User?
+    fun existsByNickname(nickname: String): Boolean
+    fun existsByNicknameAndIdNot(nickname: String, id: Long): Boolean
 }

--- a/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
@@ -1,5 +1,9 @@
 package com.stepbookstep.server.security.config
 
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -28,5 +32,22 @@ class SecurityConfig {
             }
 
         return http.build()
+    }
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        val securitySchemeName = "bearerAuth"
+        return OpenAPI()
+            .addSecurityItem(SecurityRequirement().addList(securitySchemeName))
+            .components(
+                Components().addSecuritySchemes(
+                    securitySchemeName,
+                    SecurityScheme()
+                        .name(securitySchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                )
+            )
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/security/config/WebConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/WebConfig.kt
@@ -1,0 +1,22 @@
+package com.stepbookstep.server.security.config
+
+import com.stepbookstep.server.security.jwt.AuthenticationInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * 인증 인터셉터를 등록하고,
+ * 적용/제외할 API 경로를 설정하는 Web MVC 설정 클래스
+ */
+@Configuration
+class WebConfig(
+    private val authenticationInterceptor: AuthenticationInterceptor
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(authenticationInterceptor)
+            // 헬스체크, 스웨거 제외 userId 여부로 판단됩니다.
+            .excludePathPatterns("/health", "/swagger-ui/**")
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/security/jwt/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/jwt/AuthenticationInterceptor.kt
@@ -1,0 +1,32 @@
+package com.stepbookstep.server.security.jwt
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+/**
+ * HTTP 요청마다 Authorization 헤더의 JWT를 검사하고,
+ * 유효한 경우 토큰에서 userId를 추출해 request attribute로 저장하는 인증 인터셉터
+ */
+@Component
+class AuthenticationInterceptor(
+    private val jwtProvider: JwtProvider
+) : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        // 1. 헤더에서 Authorization: Bearer {토큰} 추출
+        val authHeader = request.getHeader("Authorization")
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            val token = authHeader.substring(7)
+
+            // 2. 토큰이 유효하면 userId를 추출해서 request에 세팅
+            if (!jwtProvider.isExpired(token)) {
+                val userId = jwtProvider.getUserId(token)
+                request.setAttribute("userId", userId)
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
사용자의 온보딩 정보(닉네임, 카테고리 취향 등)를 저장하고 가입 완료 상태로 변경하는 기능을 구현하였습니다. 또한, 구현 과정에서 발생한 인증 누락 에러를 해결하기 위한 사용자 식별 로직을 추가하였습니다.

- POST /api/v1/users/onboarding : 온보딩 결과 저장 API
- GET /api/v1/users/check : 닉네임 중복 확인 API


## 🔍 참고 사항
- 온보딩에서 구체적으로 레벨을 나누는 로직은 아직 미완성이라 TODO로 주석 표시 해두었습니다.

## 🖼️ 스크린샷

- 닉네임 입력 화면
<img width="1308" height="339" alt="스크린샷 2026-01-18 오전 2 03 07" src="https://github.com/user-attachments/assets/b669c30a-aca2-4acf-bc2d-b6ce1350ef29" />

<img width="1308" height="715" alt="스크린샷 2026-01-18 오전 2 03 19" src="https://github.com/user-attachments/assets/10448ce5-e9df-4fc4-aa9c-0fcbaaaac85b" />

- 닉네임 설정 규칙을 벗어날시 에러 화면
<img width="1306" height="227" alt="스크린샷 2026-01-18 오전 2 03 43" src="https://github.com/user-attachments/assets/25adc1a5-2882-4544-af55-06f77197d9bf" />

<img width="1303" height="458" alt="스크린샷 2026-01-18 오전 2 03 56" src="https://github.com/user-attachments/assets/0ea7277e-c693-4d61-a1ce-021b597ea4a5" />

- 온보딩 정보 저장 화면
<img width="1453" height="614" alt="스크린샷 2026-01-18 오전 2 50 02" src="https://github.com/user-attachments/assets/7f4c511c-717d-428a-ba48-ddac1e7771d3" />

<img width="1444" height="393" alt="스크린샷 2026-01-18 오전 2 50 11" src="https://github.com/user-attachments/assets/2edc18d3-68d1-4dd4-b370-15d8bfe8a0c7" />



## 🔗 관련 이슈
#19

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인