### PR TITLE
[fix] 카카오 로그인 API 인증 인터셉터 제외

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/security/config/WebConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/WebConfig.kt
@@ -16,7 +16,7 @@ class WebConfig(
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(authenticationInterceptor)
-            // 헬스체크, 스웨거 제외 userId 여부로 판단됩니다.
-            .excludePathPatterns("/health", "/swagger-ui/**", "/v3/api-docs/**")
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/health", "/swagger-ui/**", "/v3/api-docs/**", "/api/v1/auth/**")
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
로그인 단계에서는 JWT가 존재하지 않아 인증 인터셉터에서 401 에러가 발생하던 문제 수정하여 로그인 요청 시 JWT 없이 접근 가능하도록 처리하였습니다.


## 🔍 참고 사항
인증이 필요한 API는 기존과 동일하게 인터셉터 적용


## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인