### PR TITLE
[feat] 루틴 리스트 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingGoalService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingGoalService.kt
@@ -5,7 +5,6 @@ import com.stepbookstep.server.domain.reading.domain.GoalMetric
 import com.stepbookstep.server.domain.reading.domain.GoalPeriod
 import com.stepbookstep.server.domain.reading.domain.ReadingGoal
 import com.stepbookstep.server.domain.reading.domain.ReadingGoalRepository
-import com.stepbookstep.server.domain.reading.domain.ReadingLog
 import com.stepbookstep.server.domain.reading.domain.ReadingLogRepository
 import com.stepbookstep.server.domain.reading.domain.UserBook
 import com.stepbookstep.server.domain.reading.domain.UserBookRepository
@@ -225,7 +224,11 @@ class ReadingGoalService(
                     // 기록이 1개만 있는 경우 (같은 날 첫 기록)
                     firstRecord.id == lastRecord.id -> {
                         // 기간 시작 전 마지막 기록을 찾아서 차이 계산
-                        val previousRecord = findLastRecordBeforeDate(userId, bookId, startDate)
+                        val previousRecord = readingLogRepository.findLastRecordBeforeDate(
+                            userId = userId,
+                            bookId = bookId,
+                            beforeDate = startDate
+                        )
                         if (previousRecord != null) {
                             (lastRecord.readQuantity!! - previousRecord.readQuantity!!).coerceAtLeast(0)
                         } else {
@@ -251,23 +254,6 @@ class ReadingGoalService(
                 durationSeconds / 60
             }
         }
-    }
-
-    /**
-     * 특정 날짜 이전의 마지막 기록 조회
-     */
-    private fun findLastRecordBeforeDate(
-        userId: Long,
-        bookId: Long,
-        beforeDate: LocalDate
-    ): ReadingLog? {
-        // 기간 시작 전날까지의 기록 중 가장 최근 기록
-        return readingLogRepository.findLastRecordInDateRange(
-            userId = userId,
-            bookId = bookId,
-            startDate = LocalDate.of(2000, 1, 1), // 충분히 과거 날짜
-            endDate = beforeDate.minusDays(1)
-        )
     }
 
     /**

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingGoalService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingGoalService.kt
@@ -147,10 +147,11 @@ class ReadingGoalService(
 
     /**
      * 사용자의 모든 활성 목표 조회 (루틴 목록)
+     * 최근 생성순으로 정렬
      */
     @Transactional(readOnly = true)
     fun getAllActiveRoutines(userId: Long): List<RoutineWithDetails> {
-        val activeGoals = readingGoalRepository.findAllByUserIdAndActiveTrue(userId)
+        val activeGoals = readingGoalRepository.findAllByUserIdAndActiveTrueOrderByCreatedAtDesc(userId)
 
         return activeGoals.mapNotNull { goal ->
             val book = bookRepository.findById(goal.bookId).getOrNull() ?: return@mapNotNull null

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -60,7 +60,6 @@ class ReadingLogService(
         if (userBook.status != targetStatus) {
             userBook.status = targetStatus
             userBook.updatedAt = OffsetDateTime.now()
-            userBookRepository.save(userBook)
         }
 
         // recordDate가 null이면 오늘 날짜 사용

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -30,7 +30,7 @@ class ReadingLogService(
         userId: Long,
         bookId: Long,
         bookStatus: ReadingLogStatus,
-        recordDate: LocalDate,
+        recordDate: LocalDate?,
         readQuantity: Int?,
         durationSeconds: Int?,
         rating: Int?
@@ -63,12 +63,15 @@ class ReadingLogService(
             userBookRepository.save(userBook)
         }
 
+        // recordDate가 null이면 오늘 날짜 사용
+        val actualRecordDate = recordDate ?: LocalDate.now()
+
         val log = readingLogRepository.save(
             ReadingLog(
                 userId = userId,
                 bookId = bookId,
                 bookStatus = bookStatus,
-                recordDate = recordDate,
+                recordDate = actualRecordDate,
                 readQuantity = readQuantity,
                 durationSeconds = durationSeconds,
                 rating = if (bookStatus == READING) null else rating
@@ -126,10 +129,27 @@ class ReadingLogService(
             throw CustomException(ErrorCode.READ_QUANTITY_REQUIRED)
         }
 
+        // 페이지 역행 검증 (이전 기록보다 적은 페이지 입력 불가)
+        validatePageProgression(userId, bookId, readQuantity)
+
         // 목표 metric에 따른 추가 검증
         validateByGoalMetric(activeGoal.metric, durationSeconds)
 
         activeGoal
+    }
+
+    /**
+     * 페이지 역행 검증
+     * - 이전 기록보다 적은 페이지를 입력할 수 없음
+     */
+    private fun validatePageProgression(userId: Long, bookId: Long, readQuantity: Int) {
+        val latestRecord = readingLogRepository.findLatestRecordByUserIdAndBookId(userId, bookId)
+
+        if (latestRecord != null && latestRecord.readQuantity != null) {
+            if (readQuantity < latestRecord.readQuantity!!) {
+                throw CustomException(ErrorCode.PAGE_CANNOT_GO_BACK)
+            }
+        }
     }
 
     private fun validateByGoalMetric(metric: GoalMetric, durationSeconds: Int?) {

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingGoalRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingGoalRepository.kt
@@ -4,7 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ReadingGoalRepository : JpaRepository<ReadingGoal, Long> {
     fun findByUserIdAndBookIdAndActiveTrue(userId: Long, bookId: Long): ReadingGoal?
-    fun findAllByUserIdAndActiveTrue(userId: Long): List<ReadingGoal>
+
+    /**
+     * 활성 목표를 최근 생성순으로 조회
+     */
+    fun findAllByUserIdAndActiveTrueOrderByCreatedAtDesc(userId: Long): List<ReadingGoal>
+
     /**
      * 가장 최근에 생성된 목표 조회 (활성/비활성 무관)
      * 완독/중지 후에도 목표를 표시하기 위해 사용

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
@@ -8,41 +8,6 @@ import java.time.LocalDate
 interface ReadingLogRepository : JpaRepository<ReadingLog, Long> {
 
     /**
-     * 특정 사용자의 특정 책에 대한 전체 누적 읽은 페이지 수
-     */
-    @Query("""
-        SELECT COALESCE(SUM(rl.readQuantity), 0)
-        FROM ReadingLog rl
-        WHERE rl.userId = :userId
-        AND rl.bookId = :bookId
-        AND rl.readQuantity IS NOT NULL
-    """)
-    fun sumTotalReadQuantityByUserIdAndBookId(
-        @Param("userId") userId: Long,
-        @Param("bookId") bookId: Long
-    ): Int
-
-    /**
-     * 특정 기간의 첫 번째 기록 조회 (가장 이른 날짜)
-     */
-    @Query("""
-        SELECT rl
-        FROM ReadingLog rl
-        WHERE rl.userId = :userId
-        AND rl.bookId = :bookId
-        AND rl.recordDate BETWEEN :startDate AND :endDate
-        AND rl.readQuantity IS NOT NULL
-        ORDER BY rl.recordDate ASC, rl.createdAt ASC
-        LIMIT 1
-    """)
-    fun findFirstRecordInDateRange(
-        @Param("userId") userId: Long,
-        @Param("bookId") bookId: Long,
-        @Param("startDate") startDate: LocalDate,
-        @Param("endDate") endDate: LocalDate
-    ): ReadingLog?
-
-    /**
      * 특정 기간의 마지막 기록 조회 (가장 늦은 날짜)
      */
     @Query("""

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
@@ -23,24 +23,6 @@ interface ReadingLogRepository : JpaRepository<ReadingLog, Long> {
     ): Int
 
     /**
-     * 특정 기간 동안 사용자가 읽은 총 페이지 수 합계
-     */
-    @Query("""
-        SELECT COALESCE(SUM(rl.readQuantity), 0)
-        FROM ReadingLog rl
-        WHERE rl.userId = :userId
-        AND rl.bookId = :bookId
-        AND rl.recordDate BETWEEN :startDate AND :endDate
-        AND rl.readQuantity IS NOT NULL
-    """)
-    fun sumReadQuantityByUserIdAndBookIdAndDateRange(
-        @Param("userId") userId: Long,
-        @Param("bookId") bookId: Long,
-        @Param("startDate") startDate: LocalDate,
-        @Param("endDate") endDate: LocalDate
-    ): Int
-
-    /**
      * 특정 기간의 첫 번째 기록 조회 (가장 이른 날짜)
      */
     @Query("""

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
@@ -99,6 +99,25 @@ interface ReadingLogRepository : JpaRepository<ReadingLog, Long> {
     ): Int
 
     /**
+     * 특정 날짜 이전의 마지막 기록 조회
+     */
+    @Query("""
+        SELECT rl
+        FROM ReadingLog rl
+        WHERE rl.userId = :userId
+        AND rl.bookId = :bookId
+        AND rl.recordDate < :beforeDate
+        AND rl.readQuantity IS NOT NULL
+        ORDER BY rl.recordDate DESC, rl.createdAt DESC
+        LIMIT 1
+    """)
+    fun findLastRecordBeforeDate(
+        @Param("userId") userId: Long,
+        @Param("bookId") bookId: Long,
+        @Param("beforeDate") beforeDate: LocalDate
+    ): ReadingLog?
+
+    /**
      * 사용자의 특정 책에 대한 가장 최근 기록 조회
      */
     @Query("""

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
@@ -41,6 +41,46 @@ interface ReadingLogRepository : JpaRepository<ReadingLog, Long> {
     ): Int
 
     /**
+     * 특정 기간의 첫 번째 기록 조회 (가장 이른 날짜)
+     */
+    @Query("""
+        SELECT rl
+        FROM ReadingLog rl
+        WHERE rl.userId = :userId
+        AND rl.bookId = :bookId
+        AND rl.recordDate BETWEEN :startDate AND :endDate
+        AND rl.readQuantity IS NOT NULL
+        ORDER BY rl.recordDate ASC, rl.createdAt ASC
+        LIMIT 1
+    """)
+    fun findFirstRecordInDateRange(
+        @Param("userId") userId: Long,
+        @Param("bookId") bookId: Long,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
+    ): ReadingLog?
+
+    /**
+     * 특정 기간의 마지막 기록 조회 (가장 늦은 날짜)
+     */
+    @Query("""
+        SELECT rl
+        FROM ReadingLog rl
+        WHERE rl.userId = :userId
+        AND rl.bookId = :bookId
+        AND rl.recordDate BETWEEN :startDate AND :endDate
+        AND rl.readQuantity IS NOT NULL
+        ORDER BY rl.recordDate DESC, rl.createdAt DESC
+        LIMIT 1
+    """)
+    fun findLastRecordInDateRange(
+        @Param("userId") userId: Long,
+        @Param("bookId") bookId: Long,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
+    ): ReadingLog?
+
+    /**
      * 특정 기간 동안 사용자가 읽은 총 시간(초) 합계
      */
     @Query("""
@@ -57,4 +97,21 @@ interface ReadingLogRepository : JpaRepository<ReadingLog, Long> {
         @Param("startDate") startDate: LocalDate,
         @Param("endDate") endDate: LocalDate
     ): Int
+
+    /**
+     * 사용자의 특정 책에 대한 가장 최근 기록 조회
+     */
+    @Query("""
+        SELECT rl
+        FROM ReadingLog rl
+        WHERE rl.userId = :userId
+        AND rl.bookId = :bookId
+        AND rl.readQuantity IS NOT NULL
+        ORDER BY rl.recordDate DESC, rl.createdAt DESC
+        LIMIT 1
+    """)
+    fun findLatestRecordByUserIdAndBookId(
+        @Param("userId") userId: Long,
+        @Param("bookId") bookId: Long
+    ): ReadingLog?
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
@@ -59,7 +59,6 @@ class ReadingController(
                 bookPublishYear = routine.bookPublishYear,
                 bookTotalPages = routine.bookTotalPages,
                 bookStatus = routine.bookStatus,
-                currentProgress = routine.currentProgress,
                 achievedAmount = routine.achievedAmount
             )
         }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
@@ -55,9 +55,12 @@ class ReadingController(
                 bookTitle = routine.bookTitle,
                 bookAuthor = routine.bookAuthor,
                 bookCoverImage = routine.bookCoverImage,
+                bookPublisher = routine.bookPublisher,
+                bookPublishYear = routine.bookPublishYear,
                 bookTotalPages = routine.bookTotalPages,
                 bookStatus = routine.bookStatus,
-                currentProgress = routine.currentProgress
+                currentProgress = routine.currentProgress,
+                achievedAmount = routine.achievedAmount
             )
         }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
@@ -6,6 +6,8 @@ import com.stepbookstep.server.domain.reading.application.ReadingLogService
 import com.stepbookstep.server.domain.reading.presentation.dto.CreateReadingLogRequest
 import com.stepbookstep.server.domain.reading.presentation.dto.CreateReadingLogResponse
 import com.stepbookstep.server.domain.reading.presentation.dto.ReadingGoalResponse
+import com.stepbookstep.server.domain.reading.presentation.dto.RoutineItem
+import com.stepbookstep.server.domain.reading.presentation.dto.RoutineListResponse
 import com.stepbookstep.server.domain.reading.presentation.dto.UpsertReadingGoalRequest
 import com.stepbookstep.server.global.response.ApiResponse
 import com.stepbookstep.server.global.response.CustomException
@@ -35,6 +37,32 @@ class ReadingController(
     private val bookRepository: BookRepository,
     private val authenticatedUserResolver: AuthenticatedUserResolver
 ) {
+
+    @Operation(
+        summary = "루틴 목록 조회",
+        description = "사용자의 모든 활성화된 독서 목표를 조회합니다. 루틴 탭에서 사용합니다."
+    )
+    @GetMapping("/routines")
+    fun getRoutineList(
+        @RequestHeader("Authorization", required = false) authorization: String?
+    ): ResponseEntity<ApiResponse<RoutineListResponse>> {
+        val userId = authenticatedUserResolver.getUserId(authorization)
+        val routines = readingGoalService.getAllActiveRoutines(userId)
+
+        val routineItems = routines.map { routine ->
+            RoutineItem.from(
+                goal = routine.goal,
+                bookTitle = routine.bookTitle,
+                bookAuthor = routine.bookAuthor,
+                bookCoverImage = routine.bookCoverImage,
+                bookTotalPages = routine.bookTotalPages,
+                bookStatus = routine.bookStatus,
+                currentProgress = routine.currentProgress
+            )
+        }
+
+        return ResponseEntity.ok(ApiResponse.ok(RoutineListResponse(routineItems)))
+    }
 
     @Operation(
         summary = "독서 목표 생성/수정/삭제",
@@ -108,6 +136,7 @@ class ReadingController(
             독서 기록을 생성합니다.
             
             [입력 규칙]
+            - recordDate: 기록 날짜 (생략 시 오늘 날짜로 자동 설정)
             - READING 상태:
               * readQuantity(읽은 페이지) 필수
               * TIME 목표인 경우 durationSeconds(읽은 시간) 필수

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/RoutineListResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/RoutineListResponse.kt
@@ -39,7 +39,6 @@ data class RoutineItem(
             bookPublishYear: Int?,
             bookTotalPages: Int,
             bookStatus: UserBookStatus,
-            currentProgress: Int,
             achievedAmount: Int
         ): RoutineItem {
             val remainingAmount = (goal.targetAmount - achievedAmount).coerceAtLeast(0)

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/RoutineListResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/RoutineListResponse.kt
@@ -19,13 +19,15 @@ data class RoutineItem(
     val bookTitle: String,
     val bookAuthor: String,
     val bookCoverImage: String?,
+    val bookPublisher: String?,
+    val bookPublishYear: Int?,
     val bookTotalPages: Int,
     val bookStatus: UserBookStatus,
     val period: GoalPeriod,
     val metric: GoalMetric,
     val targetAmount: Int,
-    val currentProgress: Int,  // 책 전체 대비 진행률 (0-100)
-    val remainingPages: Int    // 남은 페이지 수
+    val achievedAmount: Int,      // 현재 기간에 달성한 양 (페이지 또는 분)
+    val remainingAmount: Int      // 목표 달성까지 남은 양 (페이지 또는 분)
 ) {
     companion object {
         fun from(
@@ -33,12 +35,14 @@ data class RoutineItem(
             bookTitle: String,
             bookAuthor: String,
             bookCoverImage: String?,
+            bookPublisher: String?,
+            bookPublishYear: Int?,
             bookTotalPages: Int,
             bookStatus: UserBookStatus,
-            currentProgress: Int
+            currentProgress: Int,
+            achievedAmount: Int
         ): RoutineItem {
-            val readPages = (bookTotalPages * currentProgress / 100.0).toInt()
-            val remainingPages = (bookTotalPages - readPages).coerceAtLeast(0)
+            val remainingAmount = (goal.targetAmount - achievedAmount).coerceAtLeast(0)
 
             return RoutineItem(
                 goalId = goal.id,
@@ -46,13 +50,15 @@ data class RoutineItem(
                 bookTitle = bookTitle,
                 bookAuthor = bookAuthor,
                 bookCoverImage = bookCoverImage,
+                bookPublisher = bookPublisher,
+                bookPublishYear = bookPublishYear,
                 bookTotalPages = bookTotalPages,
                 bookStatus = bookStatus,
                 period = goal.period,
                 metric = goal.metric,
                 targetAmount = goal.targetAmount,
-                currentProgress = currentProgress,
-                remainingPages = remainingPages
+                achievedAmount = achievedAmount,
+                remainingAmount = remainingAmount
             )
         }
     }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/RoutineListResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/RoutineListResponse.kt
@@ -1,0 +1,59 @@
+package com.stepbookstep.server.domain.reading.presentation.dto
+
+import com.stepbookstep.server.domain.reading.domain.GoalMetric
+import com.stepbookstep.server.domain.reading.domain.GoalPeriod
+import com.stepbookstep.server.domain.reading.domain.ReadingGoal
+import com.stepbookstep.server.domain.reading.domain.UserBookStatus
+
+/**
+ * 루틴 목록 조회 응답
+ * - 활성화된 독서 목표 리스트
+ */
+data class RoutineListResponse(
+    val routines: List<RoutineItem>
+)
+
+data class RoutineItem(
+    val goalId: Long,
+    val bookId: Long,
+    val bookTitle: String,
+    val bookAuthor: String,
+    val bookCoverImage: String?,
+    val bookTotalPages: Int,
+    val bookStatus: UserBookStatus,
+    val period: GoalPeriod,
+    val metric: GoalMetric,
+    val targetAmount: Int,
+    val currentProgress: Int,  // 책 전체 대비 진행률 (0-100)
+    val remainingPages: Int    // 남은 페이지 수
+) {
+    companion object {
+        fun from(
+            goal: ReadingGoal,
+            bookTitle: String,
+            bookAuthor: String,
+            bookCoverImage: String?,
+            bookTotalPages: Int,
+            bookStatus: UserBookStatus,
+            currentProgress: Int
+        ): RoutineItem {
+            val readPages = (bookTotalPages * currentProgress / 100.0).toInt()
+            val remainingPages = (bookTotalPages - readPages).coerceAtLeast(0)
+
+            return RoutineItem(
+                goalId = goal.id,
+                bookId = goal.bookId,
+                bookTitle = bookTitle,
+                bookAuthor = bookAuthor,
+                bookCoverImage = bookCoverImage,
+                bookTotalPages = bookTotalPages,
+                bookStatus = bookStatus,
+                period = goal.period,
+                metric = goal.metric,
+                targetAmount = goal.targetAmount,
+                currentProgress = currentProgress,
+                remainingPages = remainingPages
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
@@ -129,7 +129,8 @@ enum class ErrorCode(
     DURATION_REQUIRED(5001, HttpStatus.BAD_REQUEST, "독서 시간을 입력해주세요."),
     RATING_REQUIRED(5002, HttpStatus.BAD_REQUEST, "평점을 입력해주세요."),
     INVALID_RATING(5003, HttpStatus.BAD_REQUEST, "평점은 1-5 사이여야 합니다."),
-    TARGET_AMOUNT_INVALID(5004, HttpStatus.BAD_REQUEST, "목표량은 1 이상이어야 합니다.");
+    TARGET_AMOUNT_INVALID(5004, HttpStatus.BAD_REQUEST, "목표량은 1 이상이어야 합니다."),
+    PAGE_CANNOT_GO_BACK(5005, HttpStatus.BAD_REQUEST, "이전 기록보다 적은 페이지를 입력할 수 없습니다.");
 
     companion object {
         /**

--- a/src/main/kotlin/com/stepbookstep/server/security/jwt/AuthenticatedUserResolver.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/jwt/AuthenticatedUserResolver.kt
@@ -10,8 +10,8 @@ class AuthenticatedUserResolver(
 ) {
     fun getUserId(authorizationHeader: String?): Long {
         if (authorizationHeader.isNullOrBlank()) {
-            return 1L; //테스트용 우회
-            //throw CustomException(ErrorCode.TOKEN_NOT_FOUND)
+            //return 1L; //테스트용 우회
+            throw CustomException(ErrorCode.TOKEN_NOT_FOUND)
         }
 
         if (!authorizationHeader.startsWith("Bearer ")) {


### PR DESCRIPTION
## 📌 작업한 내용
사용자의 활성화된 독서 목표 목록을 조회하는 루틴 탭 API를 구현했습니다.
### 루틴 목록 조회 API (GET /api/v1/routines)
 - 사용자의 모든 활성 독서 목표를 최근 생성 순으로 조회합니다. 
 - 현재 기간(일/주/월) 기준으로 목표 달성량을 계산합니다.
   - DAILY: 오늘 읽은 양 기준
   - WEEKLY: 이번주 읽은 양 
   - MONTHLY: 이번 달 읽은 양


## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
독서 기록을 입력 받을 때는 타이머로 입력하는 화면이 있어서 seconds로 입력을 받는데 루틴 탭의 화면에서 남은 양을 초까지 계산해서 보여주기에는 정보량이 너무 많은 것 같아서 /60 으로 정수 나눗셈 한 양을 표시하게 해두었는데 이건 오늘 회의 때 여쭤보고 수정해야 한다면 수정하겠습니다! 
그리고 페이지 입력이 누적인지 아닌지 (현재의 책 페이지를 적는건지 이번 기록 기준으로 읽은 양을 적는건지) 잘 모르겠어서 이것도 여쭤본 후 수정하겠습니닷...

## 🖼️ 스크린샷
처음 목표를 생성하고 난 후 루틴 리스트 응답
<img width="1326" height="848" alt="image" src="https://github.com/user-attachments/assets/ccf439cc-0eab-4467-bac3-d7974d70d1b3" />
<img width="1258" height="1115" alt="스크린샷 2026-01-20 153125" src="https://github.com/user-attachments/assets/3a5408d4-c869-4cdd-88af-532d4890403d" />

2분 읽고 독서 기록
<img width="1210" height="1219" alt="스크린샷 2026-01-20 153207" src="https://github.com/user-attachments/assets/71053167-4682-47d0-abb0-0021e75bc8cd" />

이후 루틴 리스트 응답 
<img width="1177" height="1143" alt="스크린샷 2026-01-20 153217" src="https://github.com/user-attachments/assets/4c008c46-1e1d-4196-afcd-67dbbb22b2cf" />
쪽수 기준 목표의 리스트 응답
<img width="1188" height="732" alt="스크린샷 2026-01-20 154346" src="https://github.com/user-attachments/assets/9dc198d3-dfac-42af-882a-d4105dccbef2" />


## 🔗 관련 이슈
closed #21 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인