### PR TITLE
[feat] 도서 필터 검색 API 구현 

### DIFF
--- a/src/main/kotlin/com/stepbookstep/StepbookstepApplication.kt
+++ b/src/main/kotlin/com/stepbookstep/StepbookstepApplication.kt
@@ -3,9 +3,11 @@ package com.stepbookstep
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableAsync
 class StepbookstepApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
@@ -2,8 +2,13 @@ package com.stepbookstep.server.domain.book.application
 
 import com.stepbookstep.server.domain.book.domain.Book
 import com.stepbookstep.server.domain.book.domain.BookRepository
+import com.stepbookstep.server.domain.book.domain.BookSpecification
+import com.stepbookstep.server.domain.book.presentation.dto.BookFilterResponse
 import com.stepbookstep.server.global.response.CustomException
 import com.stepbookstep.server.global.response.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,6 +18,17 @@ class BookQueryService(
     private val bookRepository: BookRepository,
     private val bookCacheService: BookCacheService
 ) {
+
+    companion object {
+        private const val PAGE_SIZE = 20
+        private val VALID_DIFFICULTIES = setOf(1, 2, 3)
+        private val VALID_PAGE_RANGES = setOf("~200", "201~250", "251~")
+        private val VALID_ORIGINS = setOf("한국소설", "영미소설", "중국소설", "일본소설", "프랑스소설", "독일소설")
+        private val VALID_GENRES = setOf(
+            "로맨스", "희곡", "무협소설", "판타지/환상문학", "역사소설",
+            "라이트노벨", "추리/미스터리", "과학소설(SF)", "액션/스릴러", "호러/공포소설"
+        )
+    }
 
     fun findById(id: Long): Book {
         return bookCacheService.getBookDetail(id)
@@ -28,6 +44,48 @@ class BookQueryService(
                 throw CustomException(ErrorCode.NOT_SEARCH, null)
             }
             results
+        }
+    }
+
+    fun filter(
+        difficulty: Int?,
+        pageRange: String?,
+        origin: String?,
+        genre: String?
+    ): BookFilterResponse {
+        // 유효성 검증
+        validateFilterParams(difficulty, pageRange, origin, genre)
+
+        val spec = Specification.where(BookSpecification.withDifficulty(difficulty))
+            .and(BookSpecification.withPageRange(pageRange))
+            .and(BookSpecification.withOrigin(origin))
+            .and(BookSpecification.withGenre(genre))
+
+        val pageable = PageRequest.of(0, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val result = bookRepository.findAll(spec, pageable)
+
+        return BookFilterResponse.of(
+            books = result.content
+        )
+    }
+
+    private fun validateFilterParams(
+        difficulty: Int?,
+        pageRange: String?,
+        origin: String?,
+        genre: String?
+    ) {
+        if (difficulty != null && difficulty !in VALID_DIFFICULTIES) {
+            throw CustomException(ErrorCode.INVALID_DIFFICULTY, null)
+        }
+        if (pageRange != null && pageRange !in VALID_PAGE_RANGES) {
+            throw CustomException(ErrorCode.INVALID_PAGE_RANGE, null)
+        }
+        if (origin != null && origin !in VALID_ORIGINS) {
+            throw CustomException(ErrorCode.INVALID_ORIGIN, null)
+        }
+        if (genre != null && genre !in VALID_GENRES) {
+            throw CustomException(ErrorCode.INVALID_GENRE, null)
         }
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
@@ -1,10 +1,13 @@
 package com.stepbookstep.server.domain.book.domain
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface BookRepository : JpaRepository<Book, Long> {
+interface BookRepository : JpaRepository<Book, Long>, JpaSpecificationExecutor<Book> {
 
     @Query(
         value = "SELECT * FROM books WHERE level = :level ORDER BY RAND() LIMIT 4",
@@ -18,21 +21,12 @@ interface BookRepository : JpaRepository<Book, Long> {
     """)
     fun searchByKeyword(@Param("keyword") keyword: String): List<Book>
 
-    @Query(
-        value = "SELECT * FROM books WHERE genre = :genre ORDER BY RAND() LIMIT 20",
-        nativeQuery = true
-    )
-    fun findRandomByGenre(@Param("genre") genre: String): List<Book>
+    @Query("SELECT b FROM Book b WHERE b.genre = :genre")
+    fun findAllByGenre(@Param("genre") genre: String): List<Book>
 
-    @Query(
-        value = "SELECT * FROM books WHERE item_page < 200 ORDER BY RAND() LIMIT 20",
-        nativeQuery = true
-    )
-    fun findUnder200Pages(): List<Book>
+    @Query("SELECT b FROM Book b WHERE b.itemPage < 200")
+    fun findAllUnder200Pages(): List<Book>
 
-    @Query(
-        value = "SELECT * FROM books WHERE is_bestseller = 1 ORDER BY RAND() LIMIT 20",
-        nativeQuery = true
-    )
-    fun findBestsellers(): List<Book>
+    @Query("SELECT b FROM Book b WHERE b.isBestseller = true")
+    fun findAllBestsellers(): List<Book>
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
@@ -1,0 +1,66 @@
+package com.stepbookstep.server.domain.book.domain
+
+import org.springframework.data.jpa.domain.Specification
+
+object BookSpecification {
+
+    /**
+     * 난이도 필터 (1, 2, 3)
+     */
+    fun withDifficulty(difficulty: Int?): Specification<Book> {
+        return Specification { root, _, cb ->
+            if (difficulty == null) {
+                null
+            } else {
+                cb.equal(root.get<Int>("level"), difficulty)
+            }
+        }
+    }
+
+    /**
+     * 분량 필터 (~200, 201~250, 251~)
+     */
+    fun withPageRange(pageRange: String?): Specification<Book> {
+        return Specification { root, _, cb ->
+            if (pageRange.isNullOrBlank()) {
+                null
+            } else {
+                when (pageRange) {
+                    "~200" -> cb.lessThanOrEqualTo(root.get("itemPage"), 200)
+                    "201~250" -> cb.and(
+                        cb.greaterThan(root.get("itemPage"), 200),
+                        cb.lessThanOrEqualTo(root.get("itemPage"), 250)
+                    )
+                    "251~" -> cb.greaterThan(root.get("itemPage"), 250)
+                    else -> null
+                }
+            }
+        }
+    }
+
+    /**
+     * 국가별 분류 필터
+     */
+    fun withOrigin(origin: String?): Specification<Book> {
+        return Specification { root, _, cb ->
+            if (origin.isNullOrBlank()) {
+                null
+            } else {
+                cb.equal(root.get<String>("origin"), origin)
+            }
+        }
+    }
+
+    /**
+     * 장르별 분류 필터
+     */
+    fun withGenre(genre: String?): Specification<Book> {
+        return Specification { root, _, cb ->
+            if (genre.isNullOrBlank()) {
+                null
+            } else {
+                cb.equal(root.get<String>("genre"), genre)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
@@ -26,12 +26,12 @@ object BookSpecification {
                 null
             } else {
                 when (pageRange) {
-                    "~200" -> cb.lessThanOrEqualTo(root.get("itemPage"), 200)
+                    "~200" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 200)
                     "201~250" -> cb.and(
-                        cb.greaterThan(root.get("itemPage"), 200),
-                        cb.lessThanOrEqualTo(root.get("itemPage"), 250)
+                        cb.greaterThan(root.get<Int>("itemPage"), 200),
+                        cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 250)
                     )
-                    "251~" -> cb.greaterThan(root.get("itemPage"), 250)
+                    "251~" -> cb.greaterThan(root.get<Int>("itemPage"), 250)
                     else -> null
                 }
             }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
@@ -2,6 +2,7 @@ package com.stepbookstep.server.domain.book.presentation
 
 import com.stepbookstep.server.domain.book.application.BookQueryService
 import com.stepbookstep.server.domain.book.presentation.dto.BookDetailResponse
+import com.stepbookstep.server.domain.book.presentation.dto.BookFilterResponse
 import com.stepbookstep.server.domain.book.presentation.dto.BookSearchResponse
 import com.stepbookstep.server.domain.book.presentation.dto.MyRecord
 import com.stepbookstep.server.domain.reading.domain.UserBookRepository
@@ -54,6 +55,32 @@ class BookController(
     ): ResponseEntity<ApiResponse<List<BookSearchResponse>>> {
         val books = bookQueryService.search(keyword, level)
         val response = books.map { BookSearchResponse.from(it) }
+        return ResponseEntity.ok(ApiResponse.ok(response))
+    }
+
+    @Operation(
+        summary = "도서 필터 검색",
+        description = """
+            선택한 필터 조건에 맞는 도서 목록을 조회합니다. (최대 20권씩 페이징)
+
+            ## 필터 옵션
+            - **difficulty**: 난이도 (1, 2, 3)
+            - **pageRange**: 분량 (~200, 201~250, 251~)
+            - **origin**: 국가별 (한국소설, 영미소설, 중국소설, 일본소설, 프랑스소설, 독일소설)
+            - **genre**: 장르별 (로맨스, 희곡, 무협소설, 판타지/환상문학, 역사소설, 라이트노벨, 추리/미스터리, 과학소설(SF), 액션/스릴러, 호러/공포소설)
+
+            모든 필터는 선택 사항이며, 복수 필터 적용 시 AND 조건으로 검색됩니다.
+            유효하지 않은 필터 값을 입력하면 400 Bad Request 에러가 반환됩니다.
+        """
+    )
+    @GetMapping("/filter")
+    fun filterBooks(
+        @Parameter(description = "난이도") @RequestParam(required = false) difficulty: Int?,
+        @Parameter(description = "분량") @RequestParam(required = false) pageRange: String?,
+        @Parameter(description = "국가별 분류") @RequestParam(required = false) origin: String?,
+        @Parameter(description = "장르별 분류") @RequestParam(required = false) genre: String?
+    ): ResponseEntity<ApiResponse<BookFilterResponse>> {
+        val response = bookQueryService.filter(difficulty, pageRange, origin, genre)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookFilterResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookFilterResponse.kt
@@ -1,0 +1,56 @@
+package com.stepbookstep.server.domain.book.presentation.dto
+
+import com.stepbookstep.server.domain.book.domain.Book
+
+data class BookFilterResponse(
+    val books: List<BookFilterItem>
+) {
+    companion object {
+        fun of(books: List<Book>): BookFilterResponse {
+            return BookFilterResponse(
+                books = books.map { BookFilterItem.from(it) }
+            )
+        }
+    }
+}
+
+data class BookFilterItem(
+    val bookId: Long,
+    val coverImage: String,
+    val title: String,
+    val author: String,
+    val publisher: String,
+    val pubDate: String,
+    val totalPage: Int,
+    val tags: List<String>
+) {
+    companion object {
+        fun from(book: Book): BookFilterItem {
+            val tags = mutableListOf<String>()
+
+            // 분량 태그
+            when {
+                book.itemPage <= 200 -> tags.add("~200")
+                book.itemPage <= 250 -> tags.add("201~250")
+                else -> tags.add("251~")
+            }
+
+            // 국가 태그
+            tags.add(book.origin)
+
+            // 장르 태그
+            tags.add(book.genre)
+
+            return BookFilterItem(
+                bookId = book.id,
+                coverImage = book.coverUrl,
+                title = book.title,
+                author = book.author,
+                publisher = book.publisher,
+                pubDate = book.pubYear.toString(),
+                totalPage = book.itemPage,
+                tags = tags
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeCacheService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeCacheService.kt
@@ -14,16 +14,16 @@ class HomeCacheService(
 
     @Cacheable(value = ["genreBooks"], key = "#genre")
     fun getGenreBooks(genre: String): List<Book> {
-        return bookRepository.findRandomByGenre(genre)
+        return bookRepository.findAllByGenre(genre)
     }
 
     @Cacheable(value = ["under200Books"])
     fun getUnder200Books(): List<Book> {
-        return bookRepository.findUnder200Pages()
+        return bookRepository.findAllUnder200Pages()
     }
 
     @Cacheable(value = ["bestsellerBooks"])
     fun getBestsellerBooks(): List<Book> {
-        return bookRepository.findBestsellers()
+        return bookRepository.findAllBestsellers()
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
@@ -26,9 +26,9 @@ class HomeQueryService(
             }
         }
 
-        val genreBooks = homeCacheService.getGenreBooks(genre.displayName)
-        val under200Books = homeCacheService.getUnder200Books()
-        val bestsellerBooks = homeCacheService.getBestsellerBooks()
+        val genreBooks = homeCacheService.getGenreBooks(genre.displayName).shuffled().take(20)
+        val under200Books = homeCacheService.getUnder200Books().shuffled().take(20)
+        val bestsellerBooks = homeCacheService.getBestsellerBooks().shuffled().take(20)
 
         return HomeResponse(
             genreBooks = GenreBooks.of(genre, genreBooks),

--- a/src/main/kotlin/com/stepbookstep/server/global/config/CacheWarmingRunner.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/config/CacheWarmingRunner.kt
@@ -1,0 +1,39 @@
+package com.stepbookstep.server.global.config
+
+import com.stepbookstep.server.domain.book.domain.BookGenre
+import com.stepbookstep.server.domain.home.application.HomeCacheService
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class CacheWarmingRunner(
+    private val homeCacheService: HomeCacheService
+) : ApplicationRunner {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Async
+    override fun run(args: ApplicationArguments) {
+        log.info("Cache warming started...")
+
+        try {
+            BookGenre.entries.forEach { genre ->
+                homeCacheService.getGenreBooks(genre.displayName)
+                log.info("Cached genre: ${genre.displayName}")
+            }
+
+            homeCacheService.getUnder200Books()
+            log.info("Cached under200Books")
+
+            homeCacheService.getBestsellerBooks()
+            log.info("Cached bestsellerBooks")
+
+            log.info("Cache warming completed successfully")
+        } catch (e: Exception) {
+            log.error("Cache warming failed: ${e.message}", e)
+        }
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
@@ -109,6 +109,10 @@ enum class ErrorCode(
     BOOK_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당하는 도서가 존재하지 않습니다."),
     INVALID_GENRE_ID(2001, HttpStatus.BAD_REQUEST, "유효하지 않은 장르 ID입니다. (0~10)"),
     BOOKMARK_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "등록되지 않은 북마크 입니다."),
+    INVALID_DIFFICULTY(2003, HttpStatus.BAD_REQUEST, "유효하지 않은 난이도입니다."),
+    INVALID_PAGE_RANGE(2004, HttpStatus.BAD_REQUEST, "유효하지 않은 분량 범위입니다."),
+    INVALID_ORIGIN(2005, HttpStatus.BAD_REQUEST, "유효하지 않은 국가입니다."),
+    INVALID_GENRE(2006, HttpStatus.BAD_REQUEST, "유효하지 않은 장르입니다."),
 
 
     // ========================


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
### 1. 도서 필터 검색 API 구현 (`GET /api/v1/books/filter`)
- 사용자가 선택한 조건(난이도, 분량, 국가, 장르)에 맞는 도서 목록을 조회하는 기능을 추가했습니다.
- 모든 필터는 선택 사항이며, 복수 선택 시 `AND` 조건으로 검색됩니다.
- 유효하지 않은 필터 값이 입력될 경우, 명확한 예외 처리를 위해 `400 Bad Request` 에러를 반환하도록 설계했습니다.

### 2. Redis 캐싱 전략 최적화 및 성능 개선
- **기존 방식의 문제**: DB 레벨에서 `ORDER BY RAND()`를 사용해 매번 결과가 달라졌고, 이로 인해 캐시 적중률이 낮아지는 문제가 있었습니다.
- **개선된 전략**: DB에서는 전체 데이터를 조회하여 Redis에 캐싱하는 방식에만 집중합니다.
  - 실제 응답 시에는 서버 메모리에서 `.shuffled().take(20)`를 수행하여 DB 부하를 최소화하고 캐시 효율을 극대화했습니다.
- **캐시 워밍**: 서비스 가용성을 높이기 위해 애플리케이션 시작 시 비동기`@Async`로 캐시 워밍을 수행하여 초기 응답 속도를 개선했습니다.

### 📊 성능 측정 결과
| 지표            | 기존 방식  | 새로운 방식 (Redis + Shuffle) | 개선도          |
|-----------------|--------------------------|-------------------------------|-----------------|
| 평균 응답 시간  | 2.7631 ms                | 1.1237 ms                     | 59.33% 감소     |
| P95 지연 시간   | 3.5867 ms                | 1.6576 ms                     | 53.78% 감소     |
| 성능 배수       | 1.0x                     | 2.46x                         | 2.46배 빨라짐   |

                           
## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
- **분량(PageRange) 기준**: 현재 기획상의 분량 범위가 확정되지 않아, 우선 피그마 시안을 기준으로 구현했습니다. 추후에 확정되면 수정하도록 하겠습니다!
- **캐시 워밍 범위 확대**: 캐싱 전략을 전면 수정함에 따라, 홈 화면에서 노출되는 모든 장르, 200페이지 이하 도서, 베스트셀러 데이터를 서버 기동 시점에 미리 캐싱하도록 처리했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
**- 도서 필터 검색 API**
<img width="1413" height="701" alt="image" src="https://github.com/user-attachments/assets/a2140e37-d689-4599-af62-ccd653342ffb" />
<img width="1405" height="489" alt="image" src="https://github.com/user-attachments/assets/720d306e-f84a-45e7-9991-59dd01578cb9" />


**- 유효하지 않은 난이도 level 입력 시, 에러 처리**
<img width="1402" height="334" alt="image" src="https://github.com/user-attachments/assets/6e7efb8b-7870-47a7-827e-dd0efe280d64" />


**- 유효하지 않은 분량 범위 입력 시, 에러 처리**
<img width="1402" height="339" alt="image" src="https://github.com/user-attachments/assets/826209cd-644c-4374-bca5-9ece41cdd825" />


**- 유효하지 않은 국가별 분류 입력 시, 에러 처리**
<img width="1402" height="338" alt="image" src="https://github.com/user-attachments/assets/08fef328-7ae3-4b7f-943b-5e387aa44923" />


**- 유효하지 않은 장르별 분류 입력 시, 에러 처리**
<img width="1406" height="343" alt="image" src="https://github.com/user-attachments/assets/7802a582-9f45-464b-81ab-3974d51f20a4" />



## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#37 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인