### PR TITLE
[feat] 마이페이지 API 구현 (읽기 상태 변경)

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
@@ -1,0 +1,59 @@
+package com.stepbookstep.server.domain.mypage.application
+
+import com.stepbookstep.server.domain.mypage.domain.ReadStatus
+import com.stepbookstep.server.domain.reading.domain.UserBookRepository
+import com.stepbookstep.server.global.response.CustomException
+import com.stepbookstep.server.global.response.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+
+/**
+ * user_books의 읽기 상태를 변경하는 클래스
+ */
+@Service
+class ReadingStatusService(
+    private val userBookRepository: UserBookRepository
+) {
+
+    @Transactional
+    fun updateStatus(
+        userId: Long,
+        userBookId: Long,
+        newStatus: ReadStatus,
+        rating: Int?
+    ) {
+        if (userBookId <= 0) throw CustomException(ErrorCode.INVALID_INPUT)
+
+        val userBook = userBookRepository.findById(userBookId)
+            .orElseThrow { CustomException(ErrorCode.BOOK_NOT_FOUND) }
+
+        // 내 서재 항목(userBookId)은 해당 유저만 수정 가능
+        if (userBook.userId != userId) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        when (newStatus) {
+            ReadStatus.READING -> {
+                userBook.status = ReadStatus.READING
+                // 재독서시, 데이터 보존
+            }
+
+            ReadStatus.STOPPED -> {
+                userBook.status = ReadStatus.STOPPED
+            }
+
+            ReadStatus.FINISHED -> {
+                userBook.status = ReadStatus.FINISHED
+                userBook.finishedAt = OffsetDateTime.now()
+
+                if (rating != null) {
+                    if (rating !in 1..5) throw CustomException(ErrorCode.INVALID_INPUT)
+                    userBook.rating = rating
+                }
+            }
+        }
+
+        userBook.updatedAt = OffsetDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
@@ -26,7 +26,7 @@ class ReadingStatusService(
         if (userBookId <= 0) throw CustomException(ErrorCode.INVALID_INPUT)
 
         val userBook = userBookRepository.findById(userBookId)
-            .orElseThrow { CustomException(ErrorCode.BOOK_NOT_FOUND) }
+            .orElseThrow { CustomException(ErrorCode.USER_BOOK_NOT_FOUND) }
 
         // 내 서재 항목(userBookId)은 해당 유저만 수정 가능
         if (userBook.userId != userId) {

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/dto/UpdateReadStatusRequest.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/dto/UpdateReadStatusRequest.kt
@@ -1,0 +1,8 @@
+package com.stepbookstep.server.domain.mypage.application.dto
+
+import com.stepbookstep.server.domain.mypage.domain.ReadStatus
+
+data class UpdateReadStatusRequest(
+    val status: ReadStatus,
+    val rating: Int? = null // 완독 시 별점(1~5). FINISHED일 때만 허용
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/presentation/ReadingStatusController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/presentation/ReadingStatusController.kt
@@ -1,0 +1,49 @@
+package com.stepbookstep.server.domain.mypage.presentation
+
+import com.stepbookstep.server.domain.mypage.application.ReadingStatusService
+import com.stepbookstep.server.domain.mypage.application.dto.UpdateReadStatusRequest
+import com.stepbookstep.server.global.response.ApiResponse
+import com.stepbookstep.server.security.jwt.LoginUserId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "MyPage", description = "마이페이지(읽기 상태 관리) API")
+@RestController
+@RequestMapping("/api/v1/my/books")
+class ReadingStatusController(
+    private val readingStatusService: ReadingStatusService
+) {
+
+    @Operation(
+        summary = "읽기 상태 변경",
+        description = """
+            내 서재 항목(userBookId)의 읽기 상태를 변경합니다.
+            
+            상태: READING / STOPPED / FINISHED
+        """
+    )
+    @PatchMapping("/{userBookId}/status")
+    fun updateReadStatus(
+        @Parameter(description = "내 서재 항목 ID(userBookId)", example = "10")
+        @PathVariable userBookId: Long,
+
+        @Parameter(hidden = true)
+        @LoginUserId userId: Long,
+
+        @RequestBody request: UpdateReadStatusRequest
+    ): ResponseEntity<ApiResponse<Void>> {
+
+        readingStatusService.updateStatus(
+            userId = userId,
+            userBookId = userBookId,
+            newStatus = request.status,
+            rating = request.rating
+        )
+
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
+}

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/presentation/ReadingStatusController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/presentation/ReadingStatusController.kt
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "MyPage", description = "마이페이지(읽기 상태 관리) API")

--- a/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
@@ -109,7 +109,6 @@ enum class ErrorCode(
     BOOK_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당하는 도서가 존재하지 않습니다."),
     INVALID_GENRE_ID(2001, HttpStatus.BAD_REQUEST, "유효하지 않은 장르 ID입니다. (0~10)"),
     BOOKMARK_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "등록되지 않은 북마크 입니다."),
-    USER_BOOK_NOT_FOUND(2007, HttpStatus.NOT_FOUND,"서재에 해당 도서가 존재하지 않습니다.
     INVALID_PAGE_RANGE(2004, HttpStatus.BAD_REQUEST, "유효하지 않은 분량 범위입니다."),
     INVALID_ORIGIN(2005, HttpStatus.BAD_REQUEST, "유효하지 않은 국가입니다."),
     INVALID_GENRE(2006, HttpStatus.BAD_REQUEST, "유효하지 않은 장르입니다."),

--- a/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
@@ -109,6 +109,7 @@ enum class ErrorCode(
     BOOK_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당하는 도서가 존재하지 않습니다."),
     INVALID_GENRE_ID(2001, HttpStatus.BAD_REQUEST, "유효하지 않은 장르 ID입니다. (0~10)"),
     BOOKMARK_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "등록되지 않은 북마크 입니다."),
+    INVALID_DIFFICULTY(2003, HttpStatus.BAD_REQUEST, "유효하지 않은 난이도입니다."),
     INVALID_PAGE_RANGE(2004, HttpStatus.BAD_REQUEST, "유효하지 않은 분량 범위입니다."),
     INVALID_ORIGIN(2005, HttpStatus.BAD_REQUEST, "유효하지 않은 국가입니다."),
     INVALID_GENRE(2006, HttpStatus.BAD_REQUEST, "유효하지 않은 장르입니다."),

--- a/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
@@ -109,6 +109,7 @@ enum class ErrorCode(
     BOOK_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당하는 도서가 존재하지 않습니다."),
     INVALID_GENRE_ID(2001, HttpStatus.BAD_REQUEST, "유효하지 않은 장르 ID입니다. (0~10)"),
     BOOKMARK_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "등록되지 않은 북마크 입니다."),
+    USER_BOOK_NOT_FOUND(2002, HttpStatus.NOT_FOUND,"서재에 해당 도서가 존재하지 않습니다."),
 
 
     // ========================


### PR DESCRIPTION
## 📌 작업한 내용
마이페이지에서 도서의 현재 읽기 상태를 변경할 수 있도록 PATCH API를 추가했습니다.
UserBook의 status를 기준으로 READING / STOPPED / FINISHED 상태 전환을 지원합니다.

## 🔍 참고 사항
STOPPED 상태는 읽기 전 / 중단 / 보류 상태를 포괄하는 현재 상태로 사용합니다.

## 🖼️ 스크린샷
- STOPPED → READING 상태 변경
<img width="1289" height="537" alt="스크린샷 2026-01-25 오후 4 28 53" src="https://github.com/user-attachments/assets/604f4d99-77d4-4c17-bf53-57b366732b85" />
<img width="1274" height="460" alt="스크린샷 2026-01-25 오후 4 29 07" src="https://github.com/user-attachments/assets/65d2c2ab-9291-4d75-ab84-c8c82cc90492" />


- READING → FINISHED (+ rating) 상태 변경
<img width="1289" height="526" alt="스크린샷 2026-01-25 오후 4 30 11" src="https://github.com/user-attachments/assets/f813e9b3-b147-4e6f-acee-14097b717f90" />
<img width="1272" height="464" alt="스크린샷 2026-01-25 오후 4 30 22" src="https://github.com/user-attachments/assets/078cbdd5-2335-4bbb-b2d3-5fc0801f63f1" />


- DB에 넣어둔 더미 데이터 확인
<img width="791" height="363" alt="스크린샷 2026-01-25 오후 4 31 05" src="https://github.com/user-attachments/assets/8f237d7d-3b11-4165-b002-a821469e4764" />


## 🔗 관련 이슈
#31

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인