### PR TITLE
[refactor] 도서 필터 검색 API 최종 기획안 반영

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
@@ -22,7 +22,7 @@ class BookQueryService(
     companion object {
         private const val PAGE_SIZE = 20
         private val VALID_DIFFICULTIES = setOf(1, 2, 3)
-        private val VALID_PAGE_RANGES = setOf("~200", "201~250", "251~")
+        private val VALID_PAGE_RANGES = setOf("~200", "201~250", "251~350", "351~500", "501~650", "651~")
         private val VALID_ORIGINS = setOf("한국소설", "영미소설", "중국소설", "일본소설", "프랑스소설", "독일소설")
         private val VALID_GENRES = setOf(
             "로맨스", "희곡", "무협소설", "판타지/환상문학", "역사소설",
@@ -49,15 +49,15 @@ class BookQueryService(
 
     fun filter(
         difficulty: Int?,
-        pageRange: String?,
+        pageRanges: List<String>?,
         origin: String?,
         genre: String?
     ): BookFilterResponse {
         // 유효성 검증
-        validateFilterParams(difficulty, pageRange, origin, genre)
+        validateFilterParams(difficulty, pageRanges, origin, genre)
 
         val spec = Specification.where(BookSpecification.withDifficulty(difficulty))
-            .and(BookSpecification.withPageRange(pageRange))
+            .and(BookSpecification.withPageRange(pageRanges))
             .and(BookSpecification.withOrigin(origin))
             .and(BookSpecification.withGenre(genre))
 
@@ -71,14 +71,14 @@ class BookQueryService(
 
     private fun validateFilterParams(
         difficulty: Int?,
-        pageRange: String?,
+        pageRanges: List<String>?,
         origin: String?,
         genre: String?
     ) {
         if (difficulty != null && difficulty !in VALID_DIFFICULTIES) {
             throw CustomException(ErrorCode.INVALID_DIFFICULTY, null)
         }
-        if (pageRange != null && pageRange !in VALID_PAGE_RANGES) {
+        if (!pageRanges.isNullOrEmpty() && pageRanges.any { it !in VALID_PAGE_RANGES }) {
             throw CustomException(ErrorCode.INVALID_PAGE_RANGE, null)
         }
         if (origin != null && origin !in VALID_ORIGINS) {

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
@@ -18,22 +18,38 @@ object BookSpecification {
     }
 
     /**
-     * 분량 필터 (~200, 201~250, 251~)
+     * 분량 필터 (~200, 201~250, 251~350, 351~500, 501~650, 651~)
+     * 중복 선택 가능 (OR 조건)
      */
-    fun withPageRange(pageRange: String?): Specification<Book> {
+    fun withPageRange(pageRanges: List<String>?): Specification<Book> {
         return Specification { root, _, cb ->
-            if (pageRange.isNullOrBlank()) {
+            if (pageRanges.isNullOrEmpty()) {
                 null
             } else {
-                when (pageRange) {
-                    "~200" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 200)
-                    "201~250" -> cb.and(
-                        cb.greaterThan(root.get<Int>("itemPage"), 200),
-                        cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 250)
-                    )
-                    "251~" -> cb.greaterThan(root.get<Int>("itemPage"), 250)
-                    else -> null
+                val predicates = pageRanges.mapNotNull { pageRange ->
+                    when (pageRange) {
+                        "~200" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 200)
+                        "201~250" -> cb.and(
+                            cb.greaterThan(root.get<Int>("itemPage"), 200),
+                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 250)
+                        )
+                        "251~350" -> cb.and(
+                            cb.greaterThan(root.get<Int>("itemPage"), 250),
+                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 350)
+                        )
+                        "351~500" -> cb.and(
+                            cb.greaterThan(root.get<Int>("itemPage"), 350),
+                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 500)
+                        )
+                        "501~650" -> cb.and(
+                            cb.greaterThan(root.get<Int>("itemPage"), 500),
+                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 650)
+                        )
+                        "651~" -> cb.greaterThan(root.get<Int>("itemPage"), 650)
+                        else -> null
+                    }
                 }
+                if (predicates.isEmpty()) null else cb.or(*predicates.toTypedArray())
             }
         }
     }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
@@ -65,18 +65,19 @@ class BookController(
 
             ## 필터 옵션
             - **difficulty**: 난이도 (1, 2, 3)
-            - **pageRange**: 분량 (~200, 201~250, 251~)
+            - **pageRange**: 분량 (~200, 201~250, 251~350, 351~500, 501~650, 651~) - 중복 선택 가능
             - **origin**: 국가별 (한국소설, 영미소설, 중국소설, 일본소설, 프랑스소설, 독일소설)
             - **genre**: 장르별 (로맨스, 희곡, 무협소설, 판타지/환상문학, 역사소설, 라이트노벨, 추리/미스터리, 과학소설(SF), 액션/스릴러, 호러/공포소설)
 
             모든 필터는 선택 사항이며, 복수 필터 적용 시 AND 조건으로 검색됩니다.
+            pageRange는 중복 선택 시 OR 조건으로 검색됩니다.
             유효하지 않은 필터 값을 입력하면 400 Bad Request 에러가 반환됩니다.
         """
     )
     @GetMapping("/filter")
     fun filterBooks(
         @Parameter(description = "난이도") @RequestParam(required = false) difficulty: Int?,
-        @Parameter(description = "분량") @RequestParam(required = false) pageRange: String?,
+        @Parameter(description = "분량 (중복 선택 가능)") @RequestParam(required = false) pageRange: List<String>?,
         @Parameter(description = "국가별 분류") @RequestParam(required = false) origin: String?,
         @Parameter(description = "장르별 분류") @RequestParam(required = false) genre: String?
     ): ResponseEntity<ApiResponse<BookFilterResponse>> {


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 최종 기획안이 확정되어 도서 필터 검색 API의 분량 범위를 아래와 같이 수정했습니다.
\~200쪽, 201\~250쪽, 251\~350쪽, 351\~500쪽, 501\~650쪽, 651쪽\~

- 범위를 중복 선택 가능하도록 수정했습니다.
`String?`에서 `List<String>?`로 파라미터 타입을 수정했습니다.                                                                                                                                            
 여러 범위 선택 시 `OR` 조건으로 연결됩니다. 

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
없습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
- 변경된 도서 필터 검색 API
<img width="1415" height="794" alt="image" src="https://github.com/user-attachments/assets/22832d24-3066-44eb-9b14-c39360c5e712" />
<img width="1400" height="580" alt="image" src="https://github.com/user-attachments/assets/2e513afa-3c7a-4103-b78d-3a1a35c76c1d" />


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#41 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인