### PR TITLE
[feat] 프론트엔드 CORS 설정 추가

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -8,6 +8,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: prod
       ALADIN_API_KEY: ${ALADIN_API_KEY}
+      SERVER_FORWARD_HEADERS_STRATEGY: framework
     depends_on:
       - mysql
       - redis

--- a/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
@@ -46,7 +46,7 @@ class SecurityConfig {
             "https://fix-distribute-error.d2q7zz6yc7bc0h.amplifyapp.com"
         )
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-        configuration.allowedHeaders = listOf("*")
+        configuration.allowedHeaders = listOf("Authorization", "Content-Type", "Accept")
         configuration.allowCredentials = true
         configuration.maxAge = 3600L
 

--- a/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
@@ -9,6 +9,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
@@ -17,6 +20,7 @@ class SecurityConfig {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .csrf { it.disable() }
             .formLogin { it.disable() }
             .httpBasic { it.disable() }
@@ -32,6 +36,23 @@ class SecurityConfig {
             }
 
         return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = listOf(
+            "http://localhost:5173",      // Vite
+            "https://fix-distribute-error.d2q7zz6yc7bc0h.amplifyapp.com"
+        )
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+        configuration.maxAge = 3600L
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
     }
 
     @Bean

--- a/src/main/kotlin/com/stepbookstep/server/security/config/WebConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/WebConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 /**
  * 인증 인터셉터를 등록하고,
- * 적용/제외할 API 경로를 설정하는 Web MVC 설정 클래스₩
+ * 적용/제외할 API 경로를 설정하는 Web MVC 설정 클래스
  */
 @Configuration
 class WebConfig(


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
프론트엔드 연동을 위한 `CORS` 설정을 추가했습니다.

### 1. 허용 Origin
- `localhost:5173` (Vite 개발서버)
- Amplify 배포 도메인

### 2. 허용 메서드
GET, POST, PUT, PATCH, DELETE, OPTIONS

### 3. credentials 허용
쿠키, Authorization 헤더 등 인증 정보를 포함한 요청을 허용합니다.
프론트엔드에서 `credentials: 'include'` 옵션 사용 시 필요하며, 이 설정이 없으면 로그인 세션 유지가 되지 않습니다.

### 4. preflight 캐시 (maxAge: 3600초)
브라우저는 실제 요청 전에 `OPTIONS` 메서드로 `preflight` 요청을 보내 서버가 해당 요청을 허용하는지 확인합니다.
`maxAge`를 설정하면 브라우저가 preflight 응답을 캐시하여 설정된 시간(1시간) 동안 중복 OPTIONS 요청을 생략합니다.
이를 통해 불필요한 네트워크 요청을 줄이고 성능을 개선합니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
`Spring Security`를 사용하고 있기 때문에 `SecurityConfig`에서 `CORS`를 설정했습니다.
필터 실행 순서는 **요청 → Security Filter Chain → DispatcherServlet → WebMvcConfigurer** 입니다.
Spring Security 환경에서는 `Security Filter Chain` 단계에서 CORS가 먼저 처리되어야 OPTIONS 프리플라이트 요청이 정상적으로 통과할 수 있습니다.

Docker 환경에서 환경 변수를 통해 `forward-headers-strategy`를 설정하여,
Spring Boot가 Caddy가 전달한 `X-Forwarded-*` 헤더를 인식하고 Swagger가 이를 기반으로 외부 서버 주소를 자동으로 사용하도록 구현했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#44 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인