### PR TITLE
[refactor] 검색어 미입력 시 유저 레벨별 랜덤 도서 추천 캐싱 전략 적용

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookCacheService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookCacheService.kt
@@ -16,4 +16,9 @@ class BookCacheService(
     fun getBookDetail(id: Long): Book? {
         return bookRepository.findById(id).orElse(null)
     }
+
+    @Cacheable(value = ["booksByLevel"], key = "#level")
+    fun getBooksByLevel(level: Int): List<Book> {
+        return bookRepository.findAllByLevel(level)
+    }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
@@ -37,7 +37,7 @@ class BookQueryService(
 
     fun search(keyword: String?, level: Int): List<Book> {
         return if (keyword.isNullOrBlank()) {
-            bookRepository.findRandomByLevel(level)
+            bookCacheService.getBooksByLevel(level).shuffled().take(4)
         } else {
             val results = bookRepository.searchByKeyword(keyword)
             if (results.isEmpty()) {

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
@@ -9,11 +9,7 @@ import org.springframework.data.repository.query.Param
 
 interface BookRepository : JpaRepository<Book, Long>, JpaSpecificationExecutor<Book> {
 
-    @Query(
-        value = "SELECT * FROM books WHERE level = :level ORDER BY RAND() LIMIT 4",
-        nativeQuery = true
-    )
-    fun findRandomByLevel(@Param("level") level: Int): List<Book>
+    fun findAllByLevel(level: Int): List<Book>
 
     @Query("""
         SELECT b FROM Book b

--- a/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
@@ -71,10 +71,11 @@ class RedisCacheConfig {
             )
 
         val cacheConfigurations = mapOf(
-            "genreBooks" to defaultConfig.entryTtl(Duration.ofHours(1)),
-            "under200Books" to defaultConfig.entryTtl(Duration.ofHours(6)),
+            "genreBooks" to defaultConfig.entryTtl(Duration.ofHours(6)),
+            "under200Books" to defaultConfig.entryTtl(Duration.ofHours(12)),
             "bestsellerBooks" to defaultConfig.entryTtl(Duration.ofHours(12)),
-            "bookDetail" to defaultConfig.entryTtl(Duration.ofHours(24))
+            "bookDetail" to defaultConfig.entryTtl(Duration.ofHours(24)),
+            "booksByLevel" to defaultConfig.entryTtl(Duration.ofHours(6))
         )
 
         return RedisCacheManager.builder(redisConnectionFactory)

--- a/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
@@ -72,10 +72,9 @@ class RedisCacheConfig {
 
         val cacheConfigurations = mapOf(
             "genreBooks" to defaultConfig.entryTtl(Duration.ofHours(6)),
-            "under200Books" to defaultConfig.entryTtl(Duration.ofHours(12)),
             "bestsellerBooks" to defaultConfig.entryTtl(Duration.ofHours(12)),
             "bookDetail" to defaultConfig.entryTtl(Duration.ofHours(24)),
-            "booksByLevel" to defaultConfig.entryTtl(Duration.ofHours(6))
+            "booksByLevel" to defaultConfig.entryTtl(Duration.ofHours(1))
         )
 
         return RedisCacheManager.builder(redisConnectionFactory)


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

- `ORDER BY RAND()` 쿼리를 제거하고, 캐싱과 애플리케이션 레벨 셔플 방식으로 대체했습니다.
- `BookCacheService`에 유저 레벨별 도서 조회를 위한 `getBooksByLevel` 캐싱 메서드를 추가했습니다.
- DB 풀 스캔을 제거하여 조회 성능을 개선했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->

캐싱 적용 대상을 선정하기 위해, 어떤 데이터에 캐싱 효과가 높은지 먼저 검토했습니다.
그 결과 업데이트가 자주 발생하지 않고, 조회 빈도가 높은 데이터를 중심으로 캐싱을 적용하고자 했습니다.

현재까지 다음 데이터에 대해 TTL을 적용하여 캐싱을 적용했습니다.

| 캐시 키 | TTL |
|---|---|
| `bookDetail` | 24시간 |
| `bestsellerBooks` | 12시간 |
| `under200Books` | 6시간 |
| `genreBooks` | 6시간 |
| `booksByLevel` | 6시간 | 

`bookDetail`과 같이 데이터 변경이 거의 발생하지 않는 항목은 유효 시간을 길게 설정하고,
`booksByLevel`처럼 상대적으로 변경 가능성이 있는 데이터는 짧은 유효 시간을 부여해 TTL을 차등 적용했습니다.

반면, 아래 API들은 검색 조건의 조합이 다양해서 캐시 적중률이 낮을 것으로 판단하여 캐싱을 적용하지 않았습니다.
- `GET /api/v1/books/search` : 키워드 검색
- `GET /api/v1/books/filter` : 필터 조건 조합 검색


### 1/27 수정사항
요구사항 정의서가 수정되어 `under200Books`는 캐싱을 삭제하고, `booksByLevel`의 캐싱 TTL은 6시간에서 1시간으로 수정됐습니다!

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
없습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#46 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인