### PR TITLE
[fix] HTTPS 환경에서 Mixed Content 발생 문제 해결

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -59,6 +60,7 @@ class SecurityConfig {
     fun openAPI(): OpenAPI {
         val securitySchemeName = "bearerAuth"
         return OpenAPI()
+            .addServersItem(Server().url("/").description("Default Server"))
             .addSecurityItem(SecurityRequirement().addList(securitySchemeName))
             .components(
                 Components().addSecuritySchemes(


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
Swagger UI에서 API 요청이 HTTP로 전송되어 `Mixed Content` 문제가 발생했습니다. 따라서 `openAPI()` 함수에 서버 설정을 추가하고자 합니다.

- OpenAPI 서버 URL을 상대 경로`/`로 설정했습니다.
- Swagger가 현재 페이지와 동일한 프로토콜(HTTPS)을 사용하도록 유도했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
빠른 테스트를 위해 먼저 배포하겠습니다,,🥹

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#50 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인