### PR TITLE
[feat] 도서 검색 API 개인화 추천 로직 구현

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
@@ -4,8 +4,10 @@ import com.stepbookstep.server.domain.book.domain.Book
 import com.stepbookstep.server.domain.book.domain.BookRepository
 import com.stepbookstep.server.domain.book.domain.BookSpecification
 import com.stepbookstep.server.domain.book.presentation.dto.BookFilterResponse
+import com.stepbookstep.server.domain.reading.domain.UserBookRepository
 import com.stepbookstep.server.global.response.CustomException
 import com.stepbookstep.server.global.response.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
@@ -16,12 +18,14 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class BookQueryService(
     private val bookRepository: BookRepository,
-    private val bookCacheService: BookCacheService
+    private val bookCacheService: BookCacheService,
+    private val userBookRepository: UserBookRepository
 ) {
 
     companion object {
+        private val logger = LoggerFactory.getLogger(BookQueryService::class.java)
         private const val PAGE_SIZE = 20
-        private val VALID_DIFFICULTIES = setOf(1, 2, 3)
+        private val VALID_LEVELS = setOf(1, 2, 3)
         private val VALID_PAGE_RANGES = setOf("~200", "201~250", "251~350", "351~500", "501~650", "651~")
         private val VALID_ORIGINS = setOf("한국소설", "영미소설", "중국소설", "일본소설", "프랑스소설", "독일소설")
         private val VALID_GENRES = setOf(
@@ -35,9 +39,10 @@ class BookQueryService(
             ?: throw CustomException(ErrorCode.BOOK_NOT_FOUND, null)
     }
 
-    fun search(keyword: String?, level: Int): List<Book> {
+    fun search(userId: Long, keyword: String?): List<Book> {
         return if (keyword.isNullOrBlank()) {
-            bookCacheService.getBooksByLevel(level).shuffled().take(4)
+            val userLevel = calculateUserLevel(userId)
+            bookCacheService.getBooksByLevel(userLevel).shuffled().take(4)
         } else {
             val results = bookRepository.searchByKeyword(keyword)
             if (results.isEmpty()) {
@@ -47,16 +52,35 @@ class BookQueryService(
         }
     }
 
+    private fun calculateUserLevel(userId: Long): Int {
+        val userBooks = userBookRepository.findReadingAndFinishedBooksByUserId(userId)
+
+        if (userBooks.isEmpty()) {
+            logger.info("[BookSearch] userId={}, 독서 히스토리 없음 → level=1", userId)
+            return 1
+        }
+
+        val avgScore = userBooks.map { it.book.score }.average().toInt()
+        val level = when {
+            avgScore <= 35 -> 1
+            avgScore <= 65 -> 2
+            else -> 3
+        }
+
+        logger.info("[BookSearch] userId={}, avgScore={}, level={}", userId, avgScore, level)
+        return level
+    }
+
     fun filter(
-        difficulty: Int?,
+        level: Int?,
         pageRanges: List<String>?,
         origin: String?,
         genre: String?
     ): BookFilterResponse {
         // 유효성 검증
-        validateFilterParams(difficulty, pageRanges, origin, genre)
+        validateFilterParams(level, pageRanges, origin, genre)
 
-        val spec = Specification.where(BookSpecification.withDifficulty(difficulty))
+        val spec = Specification.where(BookSpecification.withLevel(level))
             .and(BookSpecification.withPageRange(pageRanges))
             .and(BookSpecification.withOrigin(origin))
             .and(BookSpecification.withGenre(genre))
@@ -70,12 +94,12 @@ class BookQueryService(
     }
 
     private fun validateFilterParams(
-        difficulty: Int?,
+        level: Int?,
         pageRanges: List<String>?,
         origin: String?,
         genre: String?
     ) {
-        if (difficulty != null && difficulty !in VALID_DIFFICULTIES) {
+        if (level != null && level !in VALID_LEVELS) {
             throw CustomException(ErrorCode.INVALID_DIFFICULTY, null)
         }
         if (!pageRanges.isNullOrEmpty() && pageRanges.any { it !in VALID_PAGE_RANGES }) {

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
@@ -71,6 +71,9 @@ class Book(
     @Column(nullable = false)
     val level: Int = 1,
 
+    @Column(nullable = false)
+    val score: Int = 0,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "vocab_level", nullable = false, length = 20)
     val vocabLevel: VocabLevel = VocabLevel.EASY,

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
@@ -7,12 +7,12 @@ object BookSpecification {
     /**
      * 난이도 필터 (1, 2, 3)
      */
-    fun withDifficulty(difficulty: Int?): Specification<Book> {
+    fun withLevel(level: Int?): Specification<Book> {
         return Specification { root, _, cb ->
-            if (difficulty == null) {
+            if (level == null) {
                 null
             } else {
-                cb.equal(root.get<Int>("level"), difficulty)
+                cb.equal(root.get<Int>("level"), level)
             }
         }
     }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
@@ -20,4 +20,16 @@ interface UserBookRepository : JpaRepository<UserBook, Long> {
         ORDER BY ub.finishedAt DESC
     """)
     fun findFinishedBooksByUserId(@Param("userId") userId: Long): List<UserBook>
+
+    /**
+     * 사용자의 읽는 중/완독한 책 목록 조회 (추천/검색용)
+     */
+    @Query("""
+        SELECT ub
+        FROM UserBook ub
+        JOIN FETCH ub.book
+        WHERE ub.userId = :userId
+        AND ub.status IN ('READING', 'FINISHED')
+    """)
+    fun findReadingAndFinishedBooksByUserId(@Param("userId") userId: Long): List<UserBook>
 }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
### 1. 도서 필터 검색 API
  - 도서 난이도 파라미터명을 Difficulty에서 level로 변경했습니다.
  (DB 내 도서 난이도 컬럼명이 level로 정의되어 있어 이를 기준으로 통일했습니다.)

### 2. 도서 검색 API
  - 기존에는 level 값을 필수로 입력받아, 키워드 검색이 없는 경우 레벨별 도서 목록을 반환하는 구조였습니다.
  - **기획 변경(개인화 도입)** 에 따라 로직을 수정했습니다.
    - 홈 탭에서 사용 중인 **사용자 등급(점수)** 을 그대로 활용했고,
    - 사용자 점수의 평균값이 레벨 1 / 2 / 3 중 어디에 해당하는지 매핑하는 로직을 구현했습니다.
    - 해당 레벨에 맞는 도서 데이터를 랜덤으로 4권 반환하며, 독서 히스토리가 없을 경우 **Lv1** 도서 데이터를 랜덤으로 반환합니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
**- 도서 검색 API (검색어 입력 시)**
<img width="1413" height="549" alt="image" src="https://github.com/user-attachments/assets/0105c154-af5b-455d-a746-842624fcc66e" />
<img width="1407" height="559" alt="image" src="https://github.com/user-attachments/assets/1933243c-c9ea-46a1-8b2f-f1e18ddae470" />

**- 도서 검색 API (검색어 미입력 시 - 랜덤 4권 조회)**
<img width="1404" height="575" alt="image" src="https://github.com/user-attachments/assets/188e4ee8-11dc-4823-b946-c795cfa53773" />


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#57 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인