### PR TITLE
[feat] 홈 목록 조회 및 도서 상세 조회 API 수정

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
@@ -58,7 +58,7 @@ class Book(
     @Column(name = "category_id", nullable = false)
     val categoryId: Long,
 
-    @Column(name = "genre_id", nullable = false)
+    @Column(name = "genre_id", nullable = true)
     val genreId: Long?,
 
     @Column(nullable = false)

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
@@ -59,7 +59,7 @@ class Book(
     val categoryId: Long,
 
     @Column(name = "genre_id", nullable = false)
-    val genreId: Long,
+    val genreId: Long?,
 
     @Column(nullable = false)
     val weight: Int = 0,

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
@@ -25,4 +25,19 @@ interface BookRepository : JpaRepository<Book, Long>, JpaSpecificationExecutor<B
 
     @Query("SELECT b FROM Book b WHERE b.isBestseller = true")
     fun findAllBestsellers(): List<Book>
+
+    @Query("SELECT b FROM Book b WHERE b.itemPage BETWEEN :minPage AND :maxPage")
+    fun findAllByPageRange(@Param("minPage") minPage: Int, @Param("maxPage") maxPage: Int): List<Book>
+
+    @Query("SELECT b FROM Book b WHERE b.score BETWEEN :minScore AND :maxScore")
+    fun findAllByScoreRange(@Param("minScore") minScore: Int, @Param("maxScore") maxScore: Int): List<Book>
+
+    @Query("SELECT b FROM Book b WHERE b.level = 3")
+    fun findAllByLevel3(): List<Book>
+
+    @Query("SELECT b FROM Book b WHERE b.categoryId = :categoryId")
+    fun findAllByCategoryId(@Param("categoryId") categoryId: Long): List<Book>
+
+    @Query("SELECT b FROM Book b WHERE b.genreId = :genreId")
+    fun findAllByGenreId(@Param("genreId") genreId: Long): List<Book>
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
@@ -4,7 +4,6 @@ import com.stepbookstep.server.domain.book.application.BookQueryService
 import com.stepbookstep.server.domain.book.presentation.dto.BookDetailResponse
 import com.stepbookstep.server.domain.book.presentation.dto.BookFilterResponse
 import com.stepbookstep.server.domain.book.presentation.dto.BookSearchResponse
-import com.stepbookstep.server.domain.book.presentation.dto.MyRecord
 import com.stepbookstep.server.domain.reading.domain.UserBookRepository
 import com.stepbookstep.server.global.response.ApiResponse
 import com.stepbookstep.server.security.jwt.LoginUserId
@@ -22,28 +21,17 @@ class BookController(
     private val userBookRepository: UserBookRepository
 ) {
 
-    @Operation(summary = "도서 상세 조회", description = "도서 ID로 상세 정보를 조회합니다. 북마크 여부와 독서 기록이 포함됩니다.")
+    @Operation(summary = "도서 상세 조회", description = "도서 ID로 상세 정보를 조회합니다. 북마크 여부가 포함됩니다.")
     @GetMapping("/{bookId}")
     fun getBook(
         @Parameter(description = "도서 ID") @PathVariable bookId: Long,
         @Parameter(hidden = true) @LoginUserId userId: Long
     ): ResponseEntity<ApiResponse<BookDetailResponse>> {
         val book = bookQueryService.findById(bookId)
-
         val userBook = userBookRepository.findByUserIdAndBookId(userId, bookId)
-
         val isBookmarked = userBook?.isBookmarked ?: false
-        val myRecord = userBook?.let {
-            MyRecord(
-                status = it.status.name,
-                startDate = it.createdAt.toLocalDate().toString(),
-                endDate = it.finishedAt?.toLocalDate()?.toString(),
-                currentPage = it.totalPagesRead,
-                readPercent = it.progressPercent
-            )
-        }
 
-        val response = BookDetailResponse.from(book, isBookmarked = isBookmarked, myRecord = myRecord)
+        val response = BookDetailResponse.from(book, isBookmarked = isBookmarked)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookDetailResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookDetailResponse.kt
@@ -4,15 +4,13 @@ import com.stepbookstep.server.domain.book.domain.Book
 
 data class BookDetailResponse(
     val bookInfo: BookInfo,
-    val isBookmarked: Boolean,
-    val myRecord: MyRecord?
+    val isBookmarked: Boolean
 ) {
     companion object {
-        fun from(book: Book, isBookmarked: Boolean = false, myRecord: MyRecord? = null): BookDetailResponse {
+        fun from(book: Book, isBookmarked: Boolean = false): BookDetailResponse {
             return BookDetailResponse(
                 bookInfo = BookInfo.from(book),
-                isBookmarked = isBookmarked,
-                myRecord = myRecord
+                isBookmarked = isBookmarked
             )
         }
     }
@@ -29,7 +27,8 @@ data class BookInfo(
     val priceStandard: Int,
     val link: String,
     val description: String,
-    val tags: List<String>
+    val tags: List<String>,
+    val level: Int
 ) {
     companion object {
         fun from(book: Book): BookInfo {
@@ -44,7 +43,8 @@ data class BookInfo(
                 priceStandard = book.priceStandard,
                 link = book.aladinLink,
                 description = book.description,
-                tags = BookTagBuilder.buildTags(book)
+                tags = BookTagBuilder.buildTags(book),
+                level = book.level
             )
         }
     }
@@ -73,10 +73,3 @@ object BookTagBuilder {
     }
 }
 
-data class MyRecord(
-    val status: String,
-    val startDate: String?,
-    val endDate: String?,
-    val currentPage: Int,
-    val readPercent: Int
-)

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeCacheService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeCacheService.kt
@@ -26,4 +26,19 @@ class HomeCacheService(
     fun getBestsellerBooks(): List<Book> {
         return bookRepository.findAllBestsellers()
     }
+
+    @Cacheable(value = ["level3Books"])
+    fun getLevel3Books(): List<Book> {
+        return bookRepository.findAllByLevel3()
+    }
+
+    @Cacheable(value = ["categoryBooks"], key = "#categoryId")
+    fun getBooksByCategoryId(categoryId: Long): List<Book> {
+        return bookRepository.findAllByCategoryId(categoryId)
+    }
+
+    @Cacheable(value = ["genreIdBooks"], key = "#genreId")
+    fun getBooksByGenreId(genreId: Long): List<Book> {
+        return bookRepository.findAllByGenreId(genreId)
+    }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
@@ -1,39 +1,165 @@
 package com.stepbookstep.server.domain.home.application
 
-import com.stepbookstep.server.domain.book.domain.BookGenre
+import com.stepbookstep.server.domain.book.domain.Book
+import com.stepbookstep.server.domain.book.domain.BookRepository
 import com.stepbookstep.server.domain.home.presentation.dto.GenreBooks
 import com.stepbookstep.server.domain.home.presentation.dto.HomeResponse
+import com.stepbookstep.server.domain.home.presentation.dto.ReadingStatistics
 import com.stepbookstep.server.domain.home.presentation.dto.Recommendations
-import com.stepbookstep.server.global.response.CustomException
-import com.stepbookstep.server.global.response.ErrorCode
+import com.stepbookstep.server.domain.reading.application.StatisticsService
+import com.stepbookstep.server.domain.reading.domain.UserBookRepository
+import com.stepbookstep.server.domain.user.domain.UserCategoryPreferenceRepository
+import com.stepbookstep.server.domain.user.domain.UserGenrePreferenceRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Year
 
 @Service
 @Transactional(readOnly = true)
 class HomeQueryService(
-    private val homeCacheService: HomeCacheService
+    private val homeCacheService: HomeCacheService,
+    private val userCategoryPreferenceRepository: UserCategoryPreferenceRepository,
+    private val userGenrePreferenceRepository: UserGenrePreferenceRepository,
+    private val userBookRepository: UserBookRepository,
+    private val bookRepository: BookRepository,
+    private val statisticsService: StatisticsService
 ) {
 
-    fun getHome(genreIds: List<Int>?): HomeResponse {
-        val genre = when {
-            genreIds.isNullOrEmpty() -> BookGenre.entries.random()
-            else -> {
-                val hasInvalidId = genreIds.any { it < 0 || it >= BookGenre.entries.size }
-                if (hasInvalidId) throw CustomException(ErrorCode.INVALID_GENRE_ID)
-                val genres = genreIds.map { BookGenre.entries[it] }
-                genres.random()
-            }
-        }
+    fun getHome(userId: Long): HomeResponse {
+        val readingStatistics = getReadingStatistics(userId)
+        val selectedBooks = selectGenreBooksForUser(userId)
 
-        val genreBooks = homeCacheService.getGenreBooks(genre.displayName).shuffled().take(20)
-        val under200Books = homeCacheService.getUnder200Books().shuffled().take(20)
+        val (lightReadsBooks, levelUpBooks) = getPersonalizedRecommendations(userId)
         val bestsellerBooks = homeCacheService.getBestsellerBooks().shuffled().take(20)
 
         return HomeResponse(
-            genreBooks = GenreBooks.of(genre, genreBooks),
-            recommendations = Recommendations.of(under200Books, bestsellerBooks)
-            // TODO: 독서 통계 부분은 추가 구현할 예정입니다.
+            readingStatistics = readingStatistics,
+            genreBooks = GenreBooks.of(
+                type = selectedBooks.type,
+                id = selectedBooks.id,
+                name = selectedBooks.name,
+                books = selectedBooks.books
+            ),
+            recommendations = Recommendations.of(lightReadsBooks, levelUpBooks, bestsellerBooks)
         )
+    }
+
+    private fun getReadingStatistics(userId: Long): ReadingStatistics {
+        val currentYear = Year.now().value
+        val stats = statisticsService.getReadingStatistics(userId, currentYear)
+
+        val favoriteCategory = stats.categoryPreference.categories
+            .firstOrNull()?.categoryName
+
+        return ReadingStatistics(
+            finishedBookCount = stats.bookSummary.finishedBookCount,
+            cumulativeHours = stats.cumulativeTime.hours,
+            achievementRate = stats.goalAchievement.achievementRate,
+            favoriteCategory = favoriteCategory
+        )
+    }
+
+    private fun selectGenreBooksForUser(userId: Long): SelectedBooks {
+        val categoryPreferences = userCategoryPreferenceRepository.findAllByUserId(userId)
+        val genrePreferences = userGenrePreferenceRepository.findAllByUserId(userId)
+
+        val allPreferences = mutableListOf<Pair<String, Long>>()
+
+        categoryPreferences.forEach { pref ->
+            allPreferences.add("category" to pref.categoryId)
+        }
+        genrePreferences.forEach { pref ->
+            allPreferences.add("genre" to pref.genreId)
+        }
+
+        // 선택한 preference가 없으면 랜덤으로 category 또는 genre 선택
+        if (allPreferences.isEmpty()) {
+            return selectRandomCategoryOrGenre()
+        }
+
+        val shuffledPreferences = allPreferences.shuffled()
+        for (preference in shuffledPreferences) {
+            val books = when (preference.first) {
+                "category" -> homeCacheService.getBooksByCategoryId(preference.second)
+                "genre" -> homeCacheService.getBooksByGenreId(preference.second)
+                else -> emptyList()
+            }.shuffled().take(20)
+
+            if (books.isNotEmpty()) {
+                val firstBook = books.first()
+                val name = when (preference.first) {
+                    "category" -> firstBook.origin
+                    "genre" -> firstBook.genre
+                    else -> ""
+                }
+                return SelectedBooks(preference.first, preference.second, name, books)
+            }
+        }
+
+        // 선택한 preference에 매칭되는 책이 없으면 랜덤 선택
+        return selectRandomCategoryOrGenre()
+    }
+
+    private fun selectRandomCategoryOrGenre(): SelectedBooks {
+        val allBooks = bookRepository.findAll()
+
+        // categoryId가 있는 책들의 고유 categoryId 목록
+        val categoryIds = allBooks.mapNotNull { it.categoryId }.distinct()
+        // genreId가 있는 책들의 고유 genreId 목록
+        val genreIds = allBooks.mapNotNull { it.genreId }.distinct()
+
+        val allOptions = mutableListOf<Pair<String, Long>>()
+        categoryIds.forEach { allOptions.add("category" to it) }
+        genreIds.forEach { allOptions.add("genre" to it) }
+
+        if (allOptions.isEmpty()) {
+            return SelectedBooks("none", 0L, "추천도서", emptyList())
+        }
+
+        val selected = allOptions.random()
+        val books = when (selected.first) {
+            "category" -> allBooks.filter { it.categoryId == selected.second }
+            "genre" -> allBooks.filter { it.genreId == selected.second }
+            else -> emptyList()
+        }.shuffled().take(20)
+
+        if (books.isEmpty()) {
+            return SelectedBooks("none", 0L, "추천도서", emptyList())
+        }
+
+        val firstBook = books.first()
+        val name = when (selected.first) {
+            "category" -> firstBook.origin
+            "genre" -> firstBook.genre
+            else -> ""
+        }
+        return SelectedBooks(selected.first, selected.second, name, books)
+    }
+
+    private data class SelectedBooks(
+        val type: String,
+        val id: Long,
+        val name: String,
+        val books: List<Book>
+    )
+
+    private fun getPersonalizedRecommendations(userId: Long): Pair<List<Book>, List<Book>> {
+        val userBooks = userBookRepository.findReadingAndFinishedBooksByUserId(userId)
+
+        return if (userBooks.isEmpty()) {
+            val lightReads = homeCacheService.getUnder200Books().shuffled().take(20)
+            val levelUp = homeCacheService.getLevel3Books().shuffled().take(20)
+            Pair(lightReads, levelUp)
+        } else {
+            val avgPageCount = userBooks.map { it.book.itemPage }.average().toInt()
+            val avgScore = userBooks.map { it.book.score }.average().toInt()
+
+            val lightReads = bookRepository.findAllByPageRange(avgPageCount - 10, avgPageCount + 10)
+                .shuffled().take(20)
+            val levelUp = bookRepository.findAllByScoreRange(avgScore + 15, avgScore + 20)
+                .shuffled().take(20)
+
+            Pair(lightReads, levelUp)
+        }
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/HomeController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/HomeController.kt
@@ -3,15 +3,13 @@ package com.stepbookstep.server.domain.home.presentation
 import com.stepbookstep.server.domain.home.application.HomeQueryService
 import com.stepbookstep.server.domain.home.presentation.dto.HomeResponse
 import com.stepbookstep.server.global.response.ApiResponse
-import com.stepbookstep.server.global.response.CustomException
-import com.stepbookstep.server.global.response.ErrorCode
+import com.stepbookstep.server.security.jwt.LoginUserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "Home", description = "홈 화면 API")
@@ -27,46 +25,38 @@ class HomeController(
             홈 화면에 필요한 모든 데이터를 한 번에 조회합니다.
 
             ## 응답 구조
-            - **genreBooks**: 선택한 장르의 도서 목록 (최대 20권)
-            - **recommendations**: 오늘의 추천 도서 (3가지 카테고리)
-              - under200: 200쪽 미만 도서
-              - levelUp: 레벨업 도전 도서
-              - bestseller: 베스트셀러 도서
 
-            ## 프론트엔드 사용 가이드
-            recommendations의 3가지 리스트는 한 번에 전달되며,
-            탭/버튼 클릭 시 해당 배열만 렌더링하면 됩니다.
-            (추가 API 호출 불필요)
+            ### 1. readingStatistics (독서 통계)
+            - **finishedBookCount**: 누적 독서량 (완독한 책 수)
+            - **cumulativeHours**: 누적 독서 시간 (시간 단위)
+            - **achievementRate**: 목표 달성률 (0~100%)
+            - **favoriteCategory**: 가장 좋아하는 분야 (완독 기준 상위 1개)
+
+            ### 2. genreBooks (선호 분야 도서)
+            - **type**: "category" (국가별) / "genre" (장르별)
+            - **id**: 선택된 categoryId 또는 genreId
+            - **name**: 분류명 (예: "한국소설", "로맨스")
+            - **books**: 해당 분류의 도서 목록 (최대 20권)
+
+            선택 로직:
+            - 온보딩에서 선택한 categoryIds/genreIds 중 1개 랜덤 추출
+            - "잘모르겠어요" 선택 시: DB의 전체 category/genre 중 랜덤 선택
+
+            ### 3. recommendations (오늘의 추천 도서)
+            - **lightReads**: 가벼운 책 (사용자 선호분량 ±10페이지 도서)
+            - **levelUp**: 도전 레벨업 (사용자 독서등급 +15~+20 score 도서)
+            - **bestseller**: 베스트셀러 도서
+
+            ## 독서 히스토리가 없는 경우 (폴백)
+            - lightReads: ~200쪽 도서
+            - levelUp: level=3 도서
         """
     )
     @GetMapping
     fun getHome(
-        // TODO: 온보딩 API 구현 후, JWT에서 사용자 ID 추출 → User 테이블의 선호 장르 조회로 변경 예정
-        @Parameter(
-            description = """
-                장르 ID 목록 (정수 입력: 0~9)
-
-                - 0: 추리/미스터리, 1: 라이트노벨, 2: 판타지/환상문학, 3: 역사소설, 4: 과학소설(SF), 5: 호러/공포소설, 6: 무협소설, 7: 액션/스릴러, 8: 로맨스, 9: 희곡
-
-                [사용 방법]
-                - 복수 선택 시: 선택한 장르 중 1개 랜덤 추출
-                - 미입력 시: 전체 장르 중 1개 랜덤 추출
-
-                ※ Swagger UI에 string으로 표시되지만, 실제로는 정수(0~9)를 입력해야 합니다.
-                (Swagger UI에서 integer 배열의 빈 항목이 자동으로 0으로 변환되는 문제를 방지하기 위해 string으로 받고 서버에서 파싱합니다)
-            """
-        )
-        @RequestParam(required = false) genreIds: List<String>?
+        @Parameter(hidden = true) @LoginUserId userId: Long
     ): ResponseEntity<ApiResponse<HomeResponse>> {
-        val filteredIds = genreIds?.filter { it.isNotBlank() }
-        val parsedGenreIds = if (filteredIds.isNullOrEmpty()) {
-            null
-        } else {
-            filteredIds.map { id ->
-                id.toIntOrNull() ?: throw CustomException(ErrorCode.INVALID_GENRE_ID)
-            }
-        }
-        val response = homeQueryService.getHome(parsedGenreIds)
+        val response = homeQueryService.getHome(userId)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/dto/HomeResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/presentation/dto/HomeResponse.kt
@@ -1,24 +1,32 @@
 package com.stepbookstep.server.domain.home.presentation.dto
 
 import com.stepbookstep.server.domain.book.domain.Book
-import com.stepbookstep.server.domain.book.domain.BookGenre
 
 data class HomeResponse(
+    val readingStatistics: ReadingStatistics,
     val genreBooks: GenreBooks,
     val recommendations: Recommendations
-    // TODO: 독서 통계 섹션 - 독서 기록 API 연동 후 추가 예정
+)
+
+data class ReadingStatistics(
+    val finishedBookCount: Int,
+    val cumulativeHours: Int,
+    val achievementRate: Int,
+    val favoriteCategory: String?
 )
 
 data class GenreBooks(
-    val genre: String,
-    val genreId: Int,
+    val type: String,
+    val id: Long,
+    val name: String,
     val books: List<BookItem>
 ) {
     companion object {
-        fun of(genre: BookGenre, books: List<Book>): GenreBooks {
+        fun of(type: String, id: Long, name: String, books: List<Book>): GenreBooks {
             return GenreBooks(
-                genre = genre.displayName,
-                genreId = genre.ordinal,
+                type = type,
+                id = id,
+                name = name,
                 books = books.map { BookItem.from(it) }
             )
         }
@@ -26,18 +34,19 @@ data class GenreBooks(
 }
 
 data class Recommendations(
-    val under200: List<BookItem>,
+    val lightReads: List<BookItem>,
     val levelUp: List<BookItem>,
     val bestseller: List<BookItem>
 ) {
     companion object {
         fun of(
-            under200Books: List<Book>,
+            lightReadsBooks: List<Book>,
+            levelUpBooks: List<Book>,
             bestsellerBooks: List<Book>
         ): Recommendations {
             return Recommendations(
-                under200 = under200Books.map { BookItem.from(it) },
-                levelUp = emptyList(), // TODO: 레벨업 도전 도서 - API 연동 후 구현 예정
+                lightReads = lightReadsBooks.map { BookItem.from(it) },
+                levelUp = levelUpBooks.map { BookItem.from(it) },
                 bestseller = bestsellerBooks.map { BookItem.from(it) }
             )
         }

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserCategoryPreferenceRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserCategoryPreferenceRepository.kt
@@ -1,9 +1,13 @@
 package com.stepbookstep.server.domain.user.domain
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.transaction.annotation.Transactional
 
 interface UserCategoryPreferenceRepository : JpaRepository<UserCategoryPreference, Long> {
 
+    @Modifying
+    @Transactional
     fun deleteAllByUserId(userId: Long)
     fun deleteByUserIdAndCategoryIdIn(userId: Long, categoryIds: Set<Long>)
     fun findAllByUserId(userId: Long): List<UserCategoryPreference>


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
### - 홈 목록 조회 API

**1. 장르 조회**
- 홈 목록 조회 시 국가/장르를 구분하지 않고, 사용자가 선택한 항목 중에서 랜덤 추출합니다. 
- 선택 항목이 없는 경우에도 국가/장르 구분 없이 랜덤 추출합니다.
 
**2. 개인화된 추천 도서**
1) 가벼운 책 (under200)
  - 기준: 사용자 선호 분량 ±10
  - 해당 조건을 만족하는 도서 20권 랜덤 반환

2) 도전 레벨업 (levelUp)
  - 기준: 사용자 독서 등급 +15 ~ +20
  - 해당 조건을 만족하는 도서 20권 랜덤 반환

3) 베스트셀러
  - 베스트셀러로 분류된 도서
  - 독서 레벨 조건 없음

4) 예외 처리
  - 사용자의 독서 상태가 ‘읽는 중’, ‘완독한’ 도서가 하나도 없는 경우 아래와 같이 예외처리
  가벼운 책 → 200쪽 이하 도서 리스트
  도전 레벨업 → lv.3 도서 리스트

**3. 독서 통계**
전체 독서 통계 API 연동하여 데이터를 조회하고, 홈 화면에서 아래 4개 항목을 표시합니다.
누적 독서량, 누적 독서 시간, 목표 달성률, 가장 좋아하는 분야

### - 도서 상세 조회
도서 상세 조회 API에서 목표 설정 데이터가 함께 조회되던 로직은 API 역할 분리가 명확하지 않다고 판단되어 제거하였습니다.
목표 설정 관련 데이터는 기존의 목표 설정 API를 통해서만 조회하도록 분리하였습니다.


## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
- 홈 목록 조회 API
<img width="1413" height="571" alt="image" src="https://github.com/user-attachments/assets/96358825-65a4-433a-9291-3e2a28a36f07" />
<img width="1406" height="578" alt="image" src="https://github.com/user-attachments/assets/015fd4fb-0459-4e8a-8e79-e9603b529ee7" />

- 도서 상세 조회 API
<img width="1399" height="580" alt="image" src="https://github.com/user-attachments/assets/a7b54144-f7d3-4bdb-b69e-7abbe005ba47" />



## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인