### PR TITLE
[refactor] 온보딩 규칙 엔진 수정

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/OnboardingRuleEngine.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/OnboardingRuleEngine.kt
@@ -11,26 +11,45 @@ import org.springframework.stereotype.Component
 @Component
 class OnboardingRuleEngine {
 
-    data class Result(
-        val level: Int,
-        val routineType: RoutineType
+    data class Tokens(
+        val periodToken: String,
+        val amountToken: String,
+        val basisToken: String
     )
 
-    fun calculate(a: LevelAnswers): Result {
-        // TODO: 규칙 확정되면 정교화 (현재는 임시로 고정값을 반환합니다.)
-        val level = when (a.readingFrequency) {
-            ReadingFrequencyAnswer.FINISHED_RECENTLY -> 3
-            ReadingFrequencyAnswer.STOP_MIDWAY -> 2
+    fun createTokens(
+        answers: LevelAnswers,
+        preferenceCount: Int,
+    ): Tokens {
+
+        val periodToken = when (answers.readingFrequency) {
+            ReadingFrequencyAnswer.FINISHED_RECENTLY,
+            ReadingFrequencyAnswer.STOP_MIDWAY -> "하루"
+
             ReadingFrequencyAnswer.LONG_TIME_NO_BOOK,
-            ReadingFrequencyAnswer.DONT_KNOW_START -> 1
+            ReadingFrequencyAnswer.DONT_KNOW_START -> "일주일"
         }
 
-        val routineType = when (level) {
-            3 -> RoutineType.HARD
-            2 -> RoutineType.NORMAL
-            else -> RoutineType.LIGHT
+        val amountToken = when (answers.readingDuration) {
+            ReadingDurationAnswer.SHORT_CHUNKS,
+            ReadingDurationAnswer.IT_DEPENDS -> "10분"
+            ReadingDurationAnswer.ONE_CHAPTER -> "20쪽"
+            ReadingDurationAnswer.READ_LONG_TIME -> "20분"
         }
 
-        return Result(level, routineType)
+        var basisToken = when (answers.difficultyPreference) {
+            DifficultyPreferenceAnswer.THICK_OR_HARD_BOOK,
+            DifficultyPreferenceAnswer.HARD_TO_UNDERSTAND -> "얇은 책"
+
+            DifficultyPreferenceAnswer.PRESSURE_TO_FINISH,
+            DifficultyPreferenceAnswer.NO_BURDEN -> "레벨 별 추천도서"
+        }
+
+        // 선호 분류 0개면 무조건 레벨 추천
+        if (preferenceCount == 0) {
+            basisToken = "레벨 별 추천도서"
+        }
+
+        return Tokens(periodToken, amountToken, basisToken)
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/OnboardingSaveResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/application/dto/OnboardingSaveResponse.kt
@@ -1,9 +1,13 @@
 package com.stepbookstep.server.domain.onboarding.application.dto
 
-import com.stepbookstep.server.domain.onboarding.domain.enum.RoutineType
-
 data class OnboardingSaveResponse(
     val isOnboarded: Boolean,
     val level: Int,
-    val routineType: RoutineType
+    val routineTokens: RoutineTokens
+)
+
+data class RoutineTokens(
+    val period: String, // "하루" / "일주일"
+    val amount: String, // "10분" / "20쪽" / "20분"
+    val basis: String   // "얅은 책" / "레벨 별 추천도서" / "선호 분류"
 )

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/DifficultyPreferenceAnswer.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/DifficultyPreferenceAnswer.kt
@@ -1,8 +1,21 @@
 package com.stepbookstep.server.domain.onboarding.domain.enum
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 /**
  * 온보딩 레벨 측정을 위한 도서 선택 기준 질문 enum
  */
+@Schema(description = """
+레벨측정-3: 읽기에서 부담되는 요소 (basis 토큰 생성)
+
+매핑:
+- THICK_OR_HARD_BOOK -> '얇은 책'
+- HARD_TO_UNDERSTAND -> '얇은 책'
+- PRESSURE_TO_FINISH -> '레벨 별 추천도서'
+- NO_BURDEN -> '레벨 별 추천도서'
+
+단, categoryIds+genreIds가 0개인 경우 basis는 무조건 '레벨 별 추천도서'로 응답합니다.
+""")
 enum class DifficultyPreferenceAnswer {
     THICK_OR_HARD_BOOK, // 두껍거나 어려워보이는 책 -> 얇은 책
     HARD_TO_UNDERSTAND, // 무슨 말인지 잘 안 들어오는 문장 -> 장르 분류에서 선택하게 함

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingDurationAnswer.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingDurationAnswer.kt
@@ -1,8 +1,19 @@
 package com.stepbookstep.server.domain.onboarding.domain.enum
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 /**
  * 온보딩 레벨 측정을 위한 독서 시간 측정 질문 enum
  */
+@Schema(description = """
+레벨측정-2: 독서 지속 시간/스타일 (amount 토큰 생성)
+
+매핑:
+- SHORT_CHUNKS -> '10분'
+- ONE_CHAPTER -> '20쪽'
+- READ_LONG_TIME -> '20분'
+- IT_DEPENDS -> '10분'
+""")
 enum class ReadingDurationAnswer {
     SHORT_CHUNKS, // 짧게 끊어 읽는 게 좋아요 -> 10분
     ONE_CHAPTER, // 한 챕터 정도는 괜찮아요 -> 20쪽

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingFrequencyAnswer.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/domain/enum/ReadingFrequencyAnswer.kt
@@ -1,8 +1,19 @@
 package com.stepbookstep.server.domain.onboarding.domain.enum
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 /**
  * 온보딩 레벨 측정을 위한 독서 선호/빈도 측정 질문 enum
  */
+@Schema(description = """
+레벨측정-1: 독서 빈도/최근 경험 (period 토큰 생성)
+
+매핑:
+- FINISHED_RECENTLY -> '하루'
+- STOP_MIDWAY -> '하루'
+- LONG_TIME_NO_BOOK -> '일주일'
+- DONT_KNOW_START -> '일주일'
+""")
 enum class ReadingFrequencyAnswer {
     FINISHED_RECENTLY, // 최근에도 책 한 권은 끝까지 읽었어요 -> 하루
     STOP_MIDWAY, // 읽고 싶긴 한데, 자주 중간에 멈춰요 -> 하루

--- a/src/main/kotlin/com/stepbookstep/server/domain/onboarding/presentation/UserOnboardingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/onboarding/presentation/UserOnboardingController.kt
@@ -20,7 +20,17 @@ class UserOnboardingController(
         return ResponseEntity.ok(onboardingService.checkNickname(nickname))
     }
 
-    @Operation(summary = "온보딩 정보 저장", description = "사용자의 온보딩 정보를 저장하고 가입 완료 상태로 변경합니다.")
+    @Operation(
+        summary = "온보딩 정보 저장",
+        description = """
+    사용자의 온보딩 정보를 저장하고 가입 완료 상태로 변경합니다.
+
+    - routineTokens: 온보딩 결과 문구를 만들기 위한 토큰 3개
+    - period: "하루" 또는 "일주일"
+    - amount: "10분" / "20쪽" / "20분"
+    - basis: "얇은 책" 또는 "레벨 별 추천도서"
+    - 단, **categoryIds+genreIds가 0개인 경우 basis는 무조건 "레벨 별 추천도서"로 응답**
+    """)
     @PostMapping("/onboarding")
     fun saveOnboarding(
         @RequestAttribute("userId") userId: Long,

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
@@ -48,14 +48,8 @@ class User(
     @Column(name = "is_onboarded", nullable = false)
     var isOnboarded: Boolean = false,
 ) {
-    fun applyOnboardingResult(
-        nickname: String,
-        level: Int,
-        routineType: RoutineType
-    ) {
+    fun completeOnboarding(nickname: String) {
         this.nickname = nickname
-        this.level = level
-        this.routineType = routineType
         this.isOnboarded = true
         this.updatedAt = OffsetDateTime.now()
     }


### PR DESCRIPTION
## 📌 작업한 내용
온보딩 로직을 디자인 기준에 맞게 정리하고, 사용자 선택값을 기반으로 시작 루틴 문구(토큰 3개)를 일관되게 생성하도록 구조를 개선했습니다.


## 🔍 참고 사항
온보딩 답변 3문항을 각각 다음 토큰으로 매핑됩니다.
Q1 → 기간(period)
하루 / 일주일
Q2 → 분량(amount)
10분 / 20쪽 / 20분
Q3 → 기준(basis)
얇은 책 / 레벨 별 추천도서

## 🖼️ 스크린샷
<img width="1447" height="512" alt="스크린샷 2026-02-01 오전 1 45 53" src="https://github.com/user-attachments/assets/8c6bfd6e-f912-45fe-a27c-11269229363e" />
<img width="1460" height="460" alt="스크린샷 2026-02-01 오전 1 46 05" src="https://github.com/user-attachments/assets/d824e04e-29fd-4dc5-bdee-8e89aab3e219" />

## 🔗 관련 이슈
#61 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인