### PR TITLE
[refactor] 도서 필터 검색 API 분량 범위 수정

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/application/BookQueryService.kt
@@ -26,7 +26,7 @@ class BookQueryService(
         private val logger = LoggerFactory.getLogger(BookQueryService::class.java)
         private const val PAGE_SIZE = 20
         private val VALID_LEVELS = setOf(1, 2, 3)
-        private val VALID_PAGE_RANGES = setOf("~200", "201~250", "251~350", "351~500", "501~650", "651~")
+        private val VALID_PAGE_RANGES = setOf("~200", "250", "350", "500", "650", "651~")
         private val VALID_ORIGINS = setOf("한국소설", "영미소설", "중국소설", "일본소설", "프랑스소설", "독일소설")
         private val VALID_GENRES = setOf(
             "로맨스", "희곡", "무협소설", "판타지/환상문학", "역사소설",
@@ -73,23 +73,23 @@ class BookQueryService(
 
     fun filter(
         level: Int?,
-        pageRanges: List<String>?,
+        pageRange: String?,
         origin: String?,
         genre: String?,
         keyword: String?,
         cursor: Long?
     ): BookFilterResponse {
         // 필터 없이 검색어만 입력한 경우 예외 처리
-        val hasFilter = level != null || !pageRanges.isNullOrEmpty() || origin != null || genre != null
+        val hasFilter = level != null || pageRange != null || origin != null || genre != null
         if (!hasFilter && !keyword.isNullOrBlank()) {
             throw CustomException(ErrorCode.FILTER_REQUIRED, null)
         }
 
         // 유효성 검증
-        validateFilterParams(level, pageRanges, origin, genre)
+        validateFilterParams(level, pageRange, origin, genre)
 
         val spec = Specification.where(BookSpecification.withLevel(level))
-            .and(BookSpecification.withPageRange(pageRanges))
+            .and(BookSpecification.withPageRange(pageRange))
             .and(BookSpecification.withOrigin(origin))
             .and(BookSpecification.withGenre(genre))
             .and(BookSpecification.withKeyword(keyword))
@@ -110,14 +110,14 @@ class BookQueryService(
 
     private fun validateFilterParams(
         level: Int?,
-        pageRanges: List<String>?,
+        pageRange: String?,
         origin: String?,
         genre: String?
     ) {
         if (level != null && level !in VALID_LEVELS) {
             throw CustomException(ErrorCode.INVALID_DIFFICULTY, null)
         }
-        if (!pageRanges.isNullOrEmpty() && pageRanges.any { it !in VALID_PAGE_RANGES }) {
+        if (pageRange != null && pageRange !in VALID_PAGE_RANGES) {
             throw CustomException(ErrorCode.INVALID_PAGE_RANGE, null)
         }
         if (origin != null && origin !in VALID_ORIGINS) {

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookSpecification.kt
@@ -18,38 +18,28 @@ object BookSpecification {
     }
 
     /**
-     * 분량 필터 (~200, 201~250, 251~350, 351~500, 501~650, 651~)
-     * 중복 선택 가능 (OR 조건)
+     * 분량 필터 (단일 선택, 선택한 값 이하 모두 포함)
+     * ~200 → itemPage <= 200
+     * 250 → itemPage <= 250
+     * 350 → itemPage <= 350
+     * 500 → itemPage <= 500
+     * 650 → itemPage <= 650
+     * 651~ → 분량 제한 없음 (전체)
      */
-    fun withPageRange(pageRanges: List<String>?): Specification<Book> {
+    fun withPageRange(pageRange: String?): Specification<Book> {
         return Specification { root, _, cb ->
-            if (pageRanges.isNullOrEmpty()) {
+            if (pageRange.isNullOrBlank()) {
                 null
             } else {
-                val predicates = pageRanges.mapNotNull { pageRange ->
-                    when (pageRange) {
-                        "~200" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 200)
-                        "201~250" -> cb.and(
-                            cb.greaterThan(root.get<Int>("itemPage"), 200),
-                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 250)
-                        )
-                        "251~350" -> cb.and(
-                            cb.greaterThan(root.get<Int>("itemPage"), 250),
-                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 350)
-                        )
-                        "351~500" -> cb.and(
-                            cb.greaterThan(root.get<Int>("itemPage"), 350),
-                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 500)
-                        )
-                        "501~650" -> cb.and(
-                            cb.greaterThan(root.get<Int>("itemPage"), 500),
-                            cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 650)
-                        )
-                        "651~" -> cb.greaterThan(root.get<Int>("itemPage"), 650)
-                        else -> null
-                    }
+                when (pageRange) {
+                    "~200" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 200)
+                    "250" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 250)
+                    "350" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 350)
+                    "500" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 500)
+                    "650" -> cb.lessThanOrEqualTo(root.get<Int>("itemPage"), 650)
+                    "651~" -> null // 전체 분량
+                    else -> null
                 }
-                if (predicates.isEmpty()) null else cb.or(*predicates.toTypedArray())
             }
         }
     }

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/BookController.kt
@@ -67,19 +67,17 @@ class BookController(
 
             ## 필터 옵션
             - **level**: 난이도 (1, 2, 3)
-            - **pageRange**: 분량 (~200, 201~250, 251~350, 351~500, 501~650, 651~) - 중복 선택 가능
+            - **pageRange**: 분량 (~200, 250, 350, 500, 650, 651~) - 단일 선택, 선택한 값 이하 모두 포함
             - **origin**: 국가별 (한국소설, 영미소설, 중국소설, 일본소설, 프랑스소설, 독일소설)
             - **genre**: 장르별 (로맨스, 희곡, 무협소설, 판타지/환상문학, 역사소설, 라이트노벨, 추리/미스터리, 과학소설(SF), 액션/스릴러, 호러/공포소설)
             - **keyword**: 검색어 (제목, 저자, 출판사에서 검색) - 필터 선택 후 사용 가능
 
-            ## 페이지네이션 
+            ## 페이지네이션
             - **cursor**: 마지막으로 조회한 bookId (첫 요청 시 생략)
-            - **size**: 조회할 개수 (고정값 20)
             - **hasNext**: 다음 페이지 존재 여부
             - 정렬: id 오름차순
 
             모든 필터는 선택 사항이며, 복수 필터 적용 시 AND 조건으로 검색됩니다.
-            pageRange는 중복 선택 시 OR 조건으로 검색됩니다.
             keyword 입력 시 필터링된 결과 내에서 추가로 검색됩니다.
             유효하지 않은 필터 값을 입력하면 400 Bad Request 에러가 반환됩니다.
         """
@@ -87,7 +85,7 @@ class BookController(
     @GetMapping("/filter")
     fun filterBooks(
         @Parameter(description = "난이도") @RequestParam(required = false) level: Int?,
-        @Parameter(description = "분량 (중복 선택 가능)") @RequestParam(required = false) pageRange: List<String>?,
+        @Parameter(description = "분량 (단일 선택: ~200, 250, 350, 500, 650, 651~)") @RequestParam(required = false) pageRange: String?,
         @Parameter(description = "국가별 분류") @RequestParam(required = false) origin: String?,
         @Parameter(description = "장르별 분류") @RequestParam(required = false) genre: String?,
         @Parameter(description = "검색어 (제목, 저자, 출판사)") @RequestParam(required = false) keyword: String?,

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookFilterResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookFilterResponse.kt
@@ -34,7 +34,10 @@ data class BookFilterItem(
             when {
                 book.itemPage <= 200 -> tags.add("~200")
                 book.itemPage <= 250 -> tags.add("201~250")
-                else -> tags.add("251~")
+                book.itemPage <= 350 -> tags.add("251~350")
+                book.itemPage <= 500 -> tags.add("351~500")
+                book.itemPage <= 650 -> tags.add("501~650")
+                else -> tags.add("651~")
             }
 
             // 국가 태그

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookFilterResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/presentation/dto/BookFilterResponse.kt
@@ -32,11 +32,11 @@ data class BookFilterItem(
 
             // 분량 태그
             when {
-                book.itemPage <= 200 -> tags.add("~200")
-                book.itemPage <= 250 -> tags.add("201~250")
-                book.itemPage <= 350 -> tags.add("251~350")
-                book.itemPage <= 500 -> tags.add("351~500")
-                book.itemPage <= 650 -> tags.add("501~650")
+                book.itemPage <= 200 -> tags.add("~200쪽")
+                book.itemPage <= 250 -> tags.add("201~250쪽")
+                book.itemPage <= 350 -> tags.add("251~350쪽")
+                book.itemPage <= 500 -> tags.add("351~500쪽")
+                book.itemPage <= 650 -> tags.add("501~650쪽")
                 else -> tags.add("651~")
             }
 


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 요구사항 정의서가 수정됨에 따라 분량 범위를 수정했습니다.
분량범위: `~200, 250, 350, 500, 650, 651~`

- 태그 키워드는 기존대로 적용하도록 했습니다.
`~200쪽, 201~250쪽, 251~350쪽, 351~500쪽, 501~650쪽, 651쪽~ `

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
없습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
- **변경된 도서 필터 검색 API**
<img width="1412" height="375" alt="image" src="https://github.com/user-attachments/assets/562af1c0-6f6d-450f-b5fb-cc804f83f048" />
<img width="1413" height="667" alt="image" src="https://github.com/user-attachments/assets/886539d9-cb4b-47fc-8878-e99814e654b2" />

- **pageRange 350을 선택하더라도 태그 키워드는 기존과 같습니다.**
<img width="1402" height="583" alt="image" src="https://github.com/user-attachments/assets/d2493538-a9a7-47f0-9ce4-82b496931d13" />


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#65 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인