### PR TITLE
[feat] 카카오 OAuth 리다이렉트 콜백 엔드포인트 추가

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -42,7 +42,10 @@ jobs:
                 expiration: 86400000
 
           kakao:
-            admin-key: "${{ secrets.KAKAO_ADMIN_KEY }}"
+            client-id: test
+            client-secret: test
+            redirect-uri: http://localhost
+            admin-key: test
           EOF
           cp src/main/resources/application.yml src/test/resources/application.yml
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoTokenResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoTokenResponse.kt
@@ -1,0 +1,14 @@
+package com.stepbookstep.server.domain.auth.application.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KakaoTokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+
+    @JsonProperty("refresh_token")
+    val refreshToken: String,
+
+    @JsonProperty("expires_in")
+    val expiresIn: Int
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoUserMeResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoUserMeResponse.kt
@@ -2,10 +2,10 @@ package com.stepbookstep.server.domain.auth.application.dto
 
 data class KakaoUserMeResponse(
     val id: Long,
-    val kakao_account: KakaoAccount?
+    val kakaoAccount: KakaoAccount?
 ) {
     val nickname: String?
-        get() = kakao_account?.profile?.nickname
+        get() = kakaoAccount?.profile?.nickname
 }
 
 data class KakaoAccount(

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoUserMeResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoUserMeResponse.kt
@@ -1,0 +1,17 @@
+package com.stepbookstep.server.domain.auth.application.dto
+
+data class KakaoUserMeResponse(
+    val id: Long,
+    val kakao_account: KakaoAccount?
+) {
+    val nickname: String?
+        get() = kakao_account?.profile?.nickname
+}
+
+data class KakaoAccount(
+    val profile: KakaoProfile?
+)
+
+data class KakaoProfile(
+    val nickname: String?
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/presentation/AuthController.kt
@@ -11,9 +11,11 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "Auth", description = "인증/인가 기능을 제공하는 API")
@@ -38,6 +40,13 @@ class AuthController(
     fun reissue(@Valid @RequestBody req: ReissueRequest): ResponseEntity<ApiResponse<RefreshTokenService.ReissueResult>> {
         val result = refreshTokenService.reissue(req.refreshToken)
         return ResponseEntity.ok(ApiResponse.Companion.ok(result))
+    }
+
+    @Operation(summary = "카카오 OAuth 콜백", description = "카카오 로그인 완료 후 인가 코드를 받아 JWT를 발급합니다.")
+    @GetMapping("/oauth/kakao/callback")
+    fun kakaoCallback(@RequestParam code: String): ResponseEntity<ApiResponse<KakaoLoginResponse>> {
+        val result = authService.kakaoLoginWithCode(code)
+        return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
     @Operation(summary = "로그아웃", description = "클라이언트가 전달한 refreshToken을 서버에서 무효화(revoked)하여 더 이상 재발급에 사용할 수 없도록 처리합니다.")

--- a/src/main/kotlin/com/stepbookstep/server/external/kakao/KakaoApiClient.kt
+++ b/src/main/kotlin/com/stepbookstep/server/external/kakao/KakaoApiClient.kt
@@ -1,11 +1,14 @@
 package com.stepbookstep.server.external.kakao
 
+import com.stepbookstep.server.domain.auth.application.dto.KakaoTokenResponse
 import com.stepbookstep.server.global.response.CustomException
 import com.stepbookstep.server.global.response.ErrorCode
+import com.stepbookstep.server.security.jwt.KakaoProperties
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
-
+import org.springframework.http.MediaType
 /**
  * 카카오 access token(socialToken)으로 카카오 사용자 정보를 조회합니다.
  * 서버는 socialToken을 DB에 저장하지 않습니다.
@@ -13,7 +16,9 @@ import reactor.core.publisher.Mono
 
 @Component
 class KakaoApiClient(
-    private val kakaoWebClient: WebClient
+    private val kakaoWebClient: WebClient,
+    private val kakaoProperties: KakaoProperties,
+    private val kakaoAuthWebClient: WebClient
 ) {
 
     fun getMe(accessToken: String): KakaoUserMeResponse {
@@ -31,6 +36,22 @@ class KakaoApiClient(
             }
             .bodyToMono(KakaoUserMeResponse::class.java)
             .block() ?: throw CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
+    }
+
+    fun getToken(code: String, redirectUri: String): KakaoTokenResponse {
+        return kakaoAuthWebClient.post()
+            .uri("/oauth/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(
+                BodyInserters.fromFormData("grant_type", "authorization_code")
+                    .with("client_id", kakaoProperties.clientId)
+                    .with("client_secret", kakaoProperties.clientSecret)
+                    .with("redirect_uri", redirectUri)
+                    .with("code", code)
+            )
+            .retrieve()
+            .bodyToMono(KakaoTokenResponse::class.java)
+            .block()!!
     }
 }
 

--- a/src/main/kotlin/com/stepbookstep/server/external/kakao/KakaoWebClientConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/external/kakao/KakaoWebClientConfig.kt
@@ -17,4 +17,11 @@ class KakaoWebClientConfig {
             .baseUrl("https://kapi.kakao.com")
             .build()
     }
+
+    @Bean
+    fun kakaoAuthWebClient(): WebClient {
+        return WebClient.builder()
+            .baseUrl("https://kauth.kakao.com")
+            .build()
+    }
 }

--- a/src/main/kotlin/com/stepbookstep/server/security/jwt/KakaoProperties.kt
+++ b/src/main/kotlin/com/stepbookstep/server/security/jwt/KakaoProperties.kt
@@ -1,0 +1,10 @@
+package com.stepbookstep.server.security.jwt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "kakao")
+data class KakaoProperties(
+    val clientId: String,
+    val clientSecret: String,
+    val redirectUri: String
+)


### PR DESCRIPTION
## 📌 작업한 내용
기존 카카오 로그인 플로우에서 코드를 수신할 백엔드 리다이렉트 엔드포인트가 존재하지 않아, 프론트엔드 OAuth 플로우 연동이 불가능했었습니다. 이에 카카오 OAuth 콜백 엔드포인트 추가하였고 이제 카카오 로그인 페이지에서 서버 리다이렉트가 정상적으로 동작됩니다.

## 🔍 참고 사항
테스트를 위해 CI 워크플로우를 수정했습니다.

## 🖼️ 스크린샷
<img width="120" height="43" alt="스크린샷 2026-02-03 오후 10 37 43" src="https://github.com/user-attachments/assets/0fcb4f6a-2d74-4813-a8a7-d2885254cc40" />

## 🔗 관련 이슈
#67 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인