### PR TITLE
[Refact] 통계 API 선호 장르 필드 수정

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
@@ -302,10 +302,8 @@ class StatisticsService(
             categoryCountMap[category] = categoryCountMap.getOrDefault(category, 0) + 1
         }
 
-        // 내림차순 정렬 후 상위 3개만 선택
         val sortedCategories = categoryCountMap.entries
             .sortedByDescending { it.value }
-            .take(3)  // 상위 3개만
 
         val categories = sortedCategories.mapIndexed { index, entry ->
             CategoryDto(

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
@@ -298,7 +298,7 @@ class StatisticsService(
         // 장르별 집계 (Book의 genre 필드 사용)
         val categoryCountMap = mutableMapOf<String, Int>()
         finishedBooks.forEach { userBook ->
-            val category = userBook.book.genre.ifBlank { "미분류" }
+            val category = userBook.book.origin.ifBlank { "미분류" }
             categoryCountMap[category] = categoryCountMap.getOrDefault(category, 0) + 1
         }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
@@ -93,11 +93,13 @@ class StatisticsService(
         val totalMinutes = (totalSeconds / 60).toInt()
         val hours = (totalMinutes / 60)
         val minutes = (totalMinutes % 60)
+        val days=hours/24
 
         return CumulativeTimeDto(
             hours = hours,
             minutes = minutes,
-            totalMinutes = totalMinutes
+            totalMinutes = totalMinutes,
+            days=days,
         )
     }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/StatisticsDTO.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/StatisticsDTO.kt
@@ -39,7 +39,8 @@ data class MonthlyDataDto(
 data class CumulativeTimeDto(
     val hours: Int,
     val minutes: Int,
-    val totalMinutes: Int
+    val totalMinutes: Int,
+    val days: Int
 )
 
 /**


### PR DESCRIPTION
## 📌 작업한 내용
통계 API에서 선호 장르가 모두 미분류로 표시되는 오류가 있어서 확인해보니 genre 필드가 비어있어서 origin으로 변경하였습니다. 
변경 전에는 상위 3개의 장르만 내려주도록 되어있었는데 저번에 여쭤보니 모든 장르를 표에 표시하면 좋겠다고 하셔서 상위 3개만 반환하도록 하는 코드는 삭제했습니다
추가로 총 독서 시간을 day로 치환하여 내려주는 days 필드도 누락되어있어 추가했습니다! 


## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷


## 🔗 관련 이슈
closed #71 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인