### PR TITLE
[fix] 도서 데이터 중복 생성 오류 및 상태값 로직 수정

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/BookmarkService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/BookmarkService.kt
@@ -25,14 +25,14 @@ class BookmarkService(
 
         val book = bookRepository.findById(bookId)
             .orElseThrow { CustomException(ErrorCode.BOOK_NOT_FOUND) }
-    val existing = myPageUserBookRepository.findByUserIdAndBookId(userId, bookId)
+        val existing = myPageUserBookRepository.findByUserIdAndBookId(userId, bookId)
 
         if (existing == null) {
             myPageUserBookRepository.save(
                 UserBook(
                     userId = userId,
                     book = book,
-                    status = ReadStatus.STOPPED,
+                    status = ReadStatus.NOT_STARTED,
                     isBookmarked = true,
                     createdAt = OffsetDateTime.now(),
                     updatedAt = OffsetDateTime.now()

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
@@ -47,6 +47,12 @@ class ReadingStatusService(
 
             ReadStatus.STOPPED -> {
                 userBook.status = ReadStatus.STOPPED
+                userBook.finishedAt = OffsetDateTime.now()
+
+                if (rating != null) {
+                    if (rating !in 1..5) throw CustomException(ErrorCode.INVALID_INPUT)
+                    userBook.rating = rating
+                }
             }
 
             ReadStatus.FINISHED -> {

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/ReadingStatusService.kt
@@ -34,6 +34,12 @@ class ReadingStatusService(
         }
 
         when (newStatus) {
+            ReadStatus.NOT_STARTED -> {
+                userBook.status = ReadStatus.NOT_STARTED
+                userBook.finishedAt = null
+                userBook.rating = null
+            }
+
             ReadStatus.READING -> {
                 userBook.status = ReadStatus.READING
                 // 재독서시, 데이터 보존

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/domain/ReadStatus.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/domain/ReadStatus.kt
@@ -10,7 +10,8 @@ import com.stepbookstep.server.global.response.ErrorCode
 enum class ReadStatus {
     READING, //독서상태 - '읽는 중'
     FINISHED, // 독서상태 - '완독한'
-    STOPPED; // 독서상태 - '중단한' (읽고 싶은으로만 추가했을 때의 기본 상태로도 사용)
+    STOPPED, // 독서상태 - '중단한'
+    NOT_STARTED; // 읽기 전
 
     companion object {
         fun from(value: String): ReadStatus {

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/domain/ReadStatus.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/domain/ReadStatus.kt
@@ -22,6 +22,7 @@ enum class ReadStatus {
                 "READING" -> READING
                 "FINISHED" -> FINISHED
                 "STOPPED" -> STOPPED
+                "NOT_STARTED" -> NOT_STARTED
                 else -> throw CustomException(ErrorCode.INVALID_INPUT)
             }
         }

--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/presentation/MyBookController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/presentation/MyBookController.kt
@@ -27,7 +27,7 @@ class MyBookController(
         - READING: 읽는 중인 책
         - FINISHED: 완독한 책
         - PAUSED: 중단한 책
-        - BOOKMARKED: 읽고 싶은 책(북마크)
+        - NOT_STARTED: 읽기 전(북마크만 한 경우, 기본상태)
         
         기본 정렬: 최근 기록순(updatedAt DESC)
     """
@@ -38,7 +38,7 @@ class MyBookController(
             description = "서재 탭",
             example = "READING",
             schema = Schema(
-                allowableValues = ["READING", "FINISHED", "PAUSED", "BOOKMARKED"]
+                allowableValues = ["READING", "FINISHED", "PAUSED", "NOT_STARTED"]
             )
         )
         @RequestParam readStatus: String,

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBook.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBook.kt
@@ -13,10 +13,19 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import java.time.OffsetDateTime
 
 @Entity
-@Table(name = "user_books")
+@Table(
+    name = "user_books",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uq_user_book",
+            columnNames = ["user_id", "book_id"]
+        )
+    ]
+)
 class UserBook(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +40,7 @@ class UserBook(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
-    var status: ReadStatus = ReadStatus.STOPPED,
+    var status: ReadStatus = ReadStatus.NOT_STARTED,
 
     @Column(name = "created_at", nullable = false)
     val createdAt: OffsetDateTime = OffsetDateTime.now(),


### PR DESCRIPTION
## 📌 작업한 내용
1. 북마크로 새 책을 북마크할 경우 해당 책이 status = STOPPED로 저장되어 이로 인해 아직 읽지 않은 책이 중단한 책 탭에도 노출되는 문제가 발생했습니다.
-> 이에 STOPPED는 읽다가 중단한 상태 전용으로 명확화하였고, 북마크만 한 경우를 표현할 수 있는 상태 (NOT_STARTED)를 추가하였습니다. 이제 기본적으로 NOT_STARTED 상태를 가지며, 이후 도서 시작 시 NOT STARTED -> READING으로 상태가 전이됩니다.

2. 특정 도서가 마이페이지 '중단한' 탭 리스트에 중복되어 나타나는 문제가 발생했습니다.
-> 확인해보니 user_books 테이블에 유니크 제약이 없어 중복 데이터가 생긴다고 판단하여 DB 유니크 제약을 추가했습니다.

## 🔍 참고 사항
실제 DB에서 SQL로 적용이 필요합니다.
```
ALTER TABLE user_books
ADD CONSTRAINT uq_user_book UNIQUE (user_id, book_id);
```


## 🖼️ 스크린샷
<img width="223" height="198" alt="스크린샷 2026-02-06 오후 10 17 07" src="https://github.com/user-attachments/assets/8cb6913b-b062-4d2f-88e2-306922b800cc" />

북마크만 한 경우 (읽기 전) -> 읽기 상태를 읽는 중으로 바꾼 경우

## 🔗 관련 이슈
#74 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인