### PR TITLE
[Feat] 도서 로그 조회 API

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -97,6 +97,16 @@ class ReadingLogService(
             )
         )
 
+        if (bookStatus == READING) {
+            userBook.totalPagesRead = readQuantity ?: userBook.totalPagesRead
+            val totalPages = book.itemPage ?: 0
+            userBook.progressPercent =
+                if (totalPages > 0 && userBook.totalPagesRead > 0) {
+                    ((userBook.totalPagesRead.toDouble() / totalPages) * 100).toInt().coerceIn(0, 100)
+                } else 0
+        }
+
+
         if (bookStatus == FINISHED || bookStatus == STOPPED) {
             deactivateActiveGoalIfExists(userId, bookId)
         }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -228,10 +228,25 @@ class ReadingLogService(
             ?.rating
             ?: userBook.rating
 
-        // goalMetric에 따라 시간 포함 여부 결정
-        val readingLogItems = allLogs
-            .map { ReadingLogItem.from(it, totalPages, goalMetric) }
-            .reversed()
+
+        val readingLogs = allLogs.filter { it.bookStatus == READING }
+
+        val readingLogItems = readingLogs.mapIndexed { index, log ->
+            val quantity = log.readQuantity
+            val prevQuantity = if (index > 0) readingLogs[index - 1].readQuantity ?: 0 else 0
+            val pagesRead = if (quantity != null) (quantity - prevQuantity).coerceAtLeast(0) else null
+
+            val percent = if (totalPages > 0 && quantity != null) {
+                ((quantity.toDouble() / totalPages) * 100).toInt().coerceIn(0, 100)
+            } else null
+
+            ReadingLogItem(
+                logId = log.id,
+                recordDate = log.recordDate,
+                pagesRead = pagesRead,
+                durationSeconds = log.durationSeconds
+            )
+        }.reversed()
 
         return BookReadingDetailResponse(
             bookStatus = userBook.status,

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -230,15 +230,9 @@ class ReadingLogService(
 
         val allLogs = readingLogRepository.findAllByUserIdAndBookIdOrderByRecordDateAscCreatedAtAsc(userId, bookId)
 
-        val latestReadingLog = allLogs
-            .filter { it.bookStatus == READING && it.readQuantity != null }
-            .lastOrNull()
-
-        val currentPage = latestReadingLog?.readQuantity ?: 0
+        val currentPage = userBook.totalPagesRead
         val totalPages = book.itemPage
-        val progressPercent = if (totalPages > 0) {
-            ((currentPage.toDouble() / totalPages) * 100).toInt().coerceIn(0, 100)
-        } else 0
+        val progressPercent = userBook.progressPercent
 
         val startDate = allLogs.firstOrNull()?.recordDate
         val endDate = allLogs

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
@@ -135,4 +135,20 @@ interface ReadingLogRepository : JpaRepository<ReadingLog, Long> {
         @Param("userId") userId: Long,
         @Param("year") year: Int
     ): List<Array<Any>>
+
+    /**
+     * 특정 책의 전체 독서 기록 조회 (독서 상세 페이지용)
+     * 날짜 오름차순, 같은 날짜면 생성순
+     */
+    @Query("""
+        SELECT rl
+        FROM ReadingLog rl
+        WHERE rl.userId = :userId
+        AND rl.bookId = :bookId
+        ORDER BY rl.recordDate ASC, rl.createdAt ASC
+    """)
+    fun findAllByUserIdAndBookIdOrderByRecordDateAscCreatedAtAsc(
+        @Param("userId") userId: Long,
+        @Param("bookId") bookId: Long
+    ): List<ReadingLog>
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
@@ -168,9 +168,9 @@ class ReadingController(
     }
 
     @Operation(
-        summary = "독서 상세 조회",
+        summary = "독서 기록 상세 조회",
         description = """
-            특정 책의 독서 상세 정보를 조회합니다.
+            특정 책의 독서 기록 상세 정보를 조회합니다.
             - 도서 상태(읽는 중/완독/중지)와 목표 정보
             - 현재 진도 (쪽수, 퍼센트)
             - 시작일/종료일

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
@@ -3,6 +3,7 @@ package com.stepbookstep.server.domain.reading.presentation
 import com.stepbookstep.server.domain.book.domain.BookRepository
 import com.stepbookstep.server.domain.reading.application.ReadingGoalService
 import com.stepbookstep.server.domain.reading.application.ReadingLogService
+import com.stepbookstep.server.domain.reading.presentation.dto.BookReadingDetailResponse
 import com.stepbookstep.server.domain.reading.presentation.dto.CreateReadingLogRequest
 import com.stepbookstep.server.domain.reading.presentation.dto.CreateReadingLogResponse
 import com.stepbookstep.server.domain.reading.presentation.dto.ReadingGoalResponse
@@ -164,5 +165,25 @@ class ReadingController(
         )
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.created(CreateReadingLogResponse(log.id)))
+    }
+
+    @Operation(
+        summary = "독서 상세 조회",
+        description = """
+            특정 책의 독서 상세 정보를 조회합니다.
+            - 도서 상태(읽는 중/완독/중지)와 목표 정보
+            - 현재 진도 (쪽수, 퍼센트)
+            - 시작일/종료일
+            - 각 독서 기록의 날짜, 쪽수(퍼센트), 시간
+            - 완독/중지 시 별점
+        """
+    )
+    @GetMapping("/books/{bookId}/reading-detail")
+    fun getBookReadingDetail(
+        @Parameter(description = "도서 ID") @PathVariable bookId: Long,
+        @Parameter(hidden = true) @LoginUserId userId: Long
+    ): ResponseEntity<ApiResponse<BookReadingDetailResponse>> {
+        val detail = readingLogService.getBookReadingDetail(userId, bookId)
+        return ResponseEntity.ok(ApiResponse.ok(detail))
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/BookReadingDetailResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/BookReadingDetailResponse.kt
@@ -4,25 +4,29 @@ import com.stepbookstep.server.domain.mypage.domain.ReadStatus
 import com.stepbookstep.server.domain.reading.domain.GoalMetric
 import com.stepbookstep.server.domain.reading.domain.GoalPeriod
 import com.stepbookstep.server.domain.reading.domain.ReadingGoal
-import com.stepbookstep.server.domain.reading.domain.ReadingLog
 import java.time.LocalDate
 
 /**
- * 독서 상세 페이지
+ * 독서 상세 페이지 응답
  */
 data class BookReadingDetailResponse(
+    // 도서 상태 & 목표
     val bookStatus: ReadStatus,
     val goal: GoalInfo?,
 
+    // 현재 진도
     val currentPage: Int,
     val totalPages: Int,
     val progressPercent: Int,
 
+    // 시작일/종료일
     val startDate: LocalDate?,
     val endDate: LocalDate?,
 
+    // 별점 (FINISHED/STOPPED일 때만)
     val rating: Int?,
 
+    // 독서 기록 리스트 (날짜 내림차순)
     val readingLogs: List<ReadingLogItem>
 )
 
@@ -49,27 +53,6 @@ data class GoalInfo(
 data class ReadingLogItem(
     val logId: Long,
     val recordDate: LocalDate,
-    val readQuantity: Int?,
-    val progressPercent: Int?,
+    val pagesRead: Int?,
     val durationSeconds: Int?
-) {
-    companion object {
-        fun from(log: ReadingLog, totalPages: Int, goalMetric: GoalMetric?): ReadingLogItem {
-            val quantity = log.readQuantity
-            val percent = if (totalPages > 0 && quantity != null) {
-                ((quantity.toDouble() / totalPages) * 100).toInt().coerceIn(0, 100)
-            } else null
-
-            // PAGE 목표면 시간 제외, TIME 목표면 시간 포함
-            val duration = if (goalMetric == GoalMetric.TIME) log.durationSeconds else null
-
-            return ReadingLogItem(
-                logId = log.id,
-                recordDate = log.recordDate,
-                readQuantity = log.readQuantity,
-                progressPercent = percent,
-                durationSeconds = duration
-            )
-        }
-    }
-}
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/BookReadingDetailResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/BookReadingDetailResponse.kt
@@ -1,0 +1,75 @@
+package com.stepbookstep.server.domain.reading.presentation.dto
+
+import com.stepbookstep.server.domain.mypage.domain.ReadStatus
+import com.stepbookstep.server.domain.reading.domain.GoalMetric
+import com.stepbookstep.server.domain.reading.domain.GoalPeriod
+import com.stepbookstep.server.domain.reading.domain.ReadingGoal
+import com.stepbookstep.server.domain.reading.domain.ReadingLog
+import java.time.LocalDate
+
+/**
+ * 독서 상세 페이지
+ */
+data class BookReadingDetailResponse(
+    val bookStatus: ReadStatus,
+    val goal: GoalInfo?,
+
+    val currentPage: Int,
+    val totalPages: Int,
+    val progressPercent: Int,
+
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+
+    val rating: Int?,
+
+    val readingLogs: List<ReadingLogItem>
+)
+
+data class GoalInfo(
+    val goalId: Long,
+    val period: GoalPeriod,
+    val metric: GoalMetric,
+    val targetAmount: Int,
+    val isActive: Boolean
+) {
+    companion object {
+        fun from(goal: ReadingGoal): GoalInfo {
+            return GoalInfo(
+                goalId = goal.id,
+                period = goal.period,
+                metric = goal.metric,
+                targetAmount = goal.targetAmount,
+                isActive = goal.active
+            )
+        }
+    }
+}
+
+data class ReadingLogItem(
+    val logId: Long,
+    val recordDate: LocalDate,
+    val readQuantity: Int?,
+    val progressPercent: Int?,
+    val durationSeconds: Int?
+) {
+    companion object {
+        fun from(log: ReadingLog, totalPages: Int, goalMetric: GoalMetric?): ReadingLogItem {
+            val quantity = log.readQuantity
+            val percent = if (totalPages > 0 && quantity != null) {
+                ((quantity.toDouble() / totalPages) * 100).toInt().coerceIn(0, 100)
+            } else null
+
+            // PAGE 목표면 시간 제외, TIME 목표면 시간 포함
+            val duration = if (goalMetric == GoalMetric.TIME) log.durationSeconds else null
+
+            return ReadingLogItem(
+                logId = log.id,
+                recordDate = log.recordDate,
+                readQuantity = log.readQuantity,
+                progressPercent = percent,
+                durationSeconds = duration
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
독서 상세 페이지에서 사용되는 도서 로그 조회 API를 추가합니다. 
도서 상태 및 목표 정보, 현재 진도, 시작일/종료일, 별점(완독/중지 시), 독서 기록 리스트(회차별 읽은 쪽수 증분, 시간)을 응답합니다. 

## 🔍 참고 사항
각 로그 옆에 표시되는 쪽수가 누적인지 증분인지 확실치 않아서 우선 이전 기록 대비 증분으로 구현해두었습니다.

## 🖼️ 스크린샷
<img width="1076" height="659" alt="image" src="https://github.com/user-attachments/assets/9eb24897-a7d4-4e1c-abc4-28c59d8ecb52" />

## 🔗 관련 이슈
closed #76 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인