### PR TITLE
[feat] 카카오 로그인 시 email 필드 추가

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/AuthService.kt
@@ -40,9 +40,16 @@ class AuthService(
         val kakaoMe: KakaoUserMeResponse = kakaoApiClient.getMe(kakaoAccessToken)
         val providerUserId = kakaoMe.id.toString()
         val nicknameFromKakao = kakaoMe.nickname ?: "사용자"
+        val email = kakaoMe.email
+            ?: throw CustomException(ErrorCode.EMAIL_REQUIRED)
 
         // 2) 유저 조회/생성 (DB Transaction - UserService 내부에서 처리)
-        val (user, isNewUser) = userService.getOrCreateKakaoUser(providerUserId, nicknameFromKakao)
+        val (user, isNewUser) =
+            userService.getOrCreateKakaoUser(
+                providerUserId = providerUserId,
+                nickname = nicknameFromKakao,
+                email = email
+            )
 
         // 3) JWT 발급 (CPU 연산)
         val accessToken = jwtProvider.createToken(user.id, TokenType.ACCESS)
@@ -55,7 +62,8 @@ class AuthService(
             accessToken = accessToken,
             refreshToken = refreshToken,
             isNewUser = isNewUser,
-            nickname = user.nickname
+            nickname = user.nickname,
+            email = user.email
         )
     }
 
@@ -76,8 +84,15 @@ class AuthService(
         val kakaoMe = kakaoApiClient.getMe(kakaoAccessToken)
         val providerUserId = kakaoMe.id.toString()
         val nicknameFromKakao = kakaoMe.nickname ?: "사용자"
+        val email = kakaoMe.email
+            ?: throw CustomException(ErrorCode.EMAIL_REQUIRED)
 
-        val (user, isNewUser) = userService.getOrCreateKakaoUser(providerUserId, nicknameFromKakao)
+        val (user, isNewUser) =
+            userService.getOrCreateKakaoUser(
+                providerUserId = providerUserId,
+                nickname = nicknameFromKakao,
+                email = email
+            )
 
         val accessToken = jwtProvider.createToken(user.id, TokenType.ACCESS)
         val refreshToken = jwtProvider.createToken(user.id, TokenType.REFRESH)
@@ -88,7 +103,8 @@ class AuthService(
             accessToken = accessToken,
             refreshToken = refreshToken,
             isNewUser = isNewUser,
-            nickname = user.nickname
+            nickname = user.nickname,
+            email = user.email
         )
     }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoLoginResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoLoginResponse.kt
@@ -4,5 +4,6 @@ data class KakaoLoginResponse(
     val accessToken: String,
     val refreshToken: String,
     val isNewUser: Boolean,
-    val nickname: String?
+    val nickname: String?,
+    val email: String?
 )

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoUserMeResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoUserMeResponse.kt
@@ -1,15 +1,23 @@
 package com.stepbookstep.server.domain.auth.application.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class KakaoUserMeResponse(
     val id: Long,
+
+    @JsonProperty("kakao_account")
     val kakaoAccount: KakaoAccount?
 ) {
     val nickname: String?
         get() = kakaoAccount?.profile?.nickname
+
+    val email: String?
+        get() = kakaoAccount?.email
 }
 
 data class KakaoAccount(
-    val profile: KakaoProfile?
+    val profile: KakaoProfile?,
+    val email: String?
 )
 
 data class KakaoProfile(

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
@@ -24,11 +24,12 @@ class UserService(
      * 카카오 계정 정보를 바탕으로 새로운 사용자를 생성하고 저장
      */
     @Transactional
-    fun createKakaoUser(providerUserId: String, nickname: String): User {
+    fun createKakaoUser(providerUserId: String, nickname: String, email: String): User {
         val user = User(
             provider = "KAKAO",
             providerUserId = providerUserId,
             nickname = nickname,
+            email = email
         )
         return userRepository.save(user)
     }
@@ -37,7 +38,7 @@ class UserService(
      * @return Pair(유저 객체, 신규 가입 여부)
      */
     @Transactional
-    fun getOrCreateKakaoUser(providerUserId: String, nickname: String): Pair<User, Boolean> {
+    fun getOrCreateKakaoUser(providerUserId: String, nickname: String, email: String): Pair<User, Boolean> {
         val existingUser = userRepository.findByProviderAndProviderUserId("KAKAO", providerUserId)
 
         return if (existingUser != null) {
@@ -47,6 +48,7 @@ class UserService(
                 provider = "KAKAO",
                 providerUserId = providerUserId,
                 nickname = nickname,
+                email = email
             )
             userRepository.save(newUser) to true
         }

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
@@ -31,6 +31,9 @@ class User(
     @Column(nullable = false)
     var status: String = "ACTIVE",
 
+    @Column(nullable = false)
+    var email: String,
+
     @Column(name = "created_at", nullable = false)
     val createdAt: OffsetDateTime = OffsetDateTime.now(),
 

--- a/src/main/kotlin/com/stepbookstep/server/external/kakao/KakaoUserMeResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/external/kakao/KakaoUserMeResponse.kt
@@ -14,7 +14,12 @@ data class KakaoUserMeResponse(
     val nickname: String?
         get() = kakaoAccount?.profile?.nickname
 
+    val email: String?
+        get() = kakaoAccount?.email
+
     data class KakaoAccount(
+        val email: String? = null,
+
         val profile: Profile? = null
     )
 

--- a/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/response/ErrorCode.kt
@@ -34,6 +34,7 @@ enum class ErrorCode(
     INVALID_INPUT(400_002, HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
     NULL_VALUE(400_003, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
     INVALID_NICKNAME(400_004, HttpStatus.BAD_REQUEST, "닉네임은 필수입니다."),
+    EMAIL_REQUIRED(400_405, HttpStatus.BAD_REQUEST, "카카오 이메일 동의가 필요합니다."),
 
 
     // ========================


### PR DESCRIPTION
## 📌 작업한 내용
카카오 소셜 로그인을 통해 회원가입을 진행할 때, 카카오 디벨로퍼 콘솔에서 카카오계정(이메일)을 필수 동의로 설정하고
회원가입 시 이메일 값이 DB에 저장됩니다.

## 🔍 참고 사항
기존 회원가입한 계정으로 테스트 진행 시 필드 추가로 문제가 생기면 카카오톡->설정->카카오계정->계정 이용->외부서비스->stepbookstep 에서 연결 해제 후 다시 가입을 진행해주세요

vscode에서도 코드 수정이 필요합니다 수정 뒤 저장하고 다시 실행하면 됩니다
```
app.get("/auth/kakao", (req, res) => {
  const clientId = process.env.KAKAO_CLIENT_ID;
  const redirectUri = process.env.KAKAO_REDIRECT_URI;

  const scope = "profile_nickname account_email"; // 이 코드 수정

```

## 🖼️ 스크린샷
<img width="439" height="191" alt="스크린샷 2026-02-07 오후 11 44 02" src="https://github.com/user-attachments/assets/fab80cc1-3865-44be-a84e-94ebce5150af" />


## 🔗 관련 이슈
#79 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인