### PR TITLE
[Feat] 독서 기록 생성 응답에 finishedCount 추가

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -37,7 +37,7 @@ class ReadingLogService(
         readQuantity: Int?,
         durationSeconds: Int?,
         rating: Int?
-    ): ReadingLog {
+    ): CreateLogResult {
         validateBookExists(bookId)
 
         validateByStatus(
@@ -111,7 +111,11 @@ class ReadingLogService(
             deactivateActiveGoalIfExists(userId, bookId)
         }
 
-        return log
+        val finishedCount: Int? = if (bookStatus == FINISHED) {
+            readingLogRepository.countByUserIdAndBookIdAndBookStatus(userId, bookId, FINISHED)
+        } else null
+
+        return CreateLogResult(log, finishedCount)
     }
 
     private fun validateBookExists(bookId: Long) {
@@ -277,3 +281,8 @@ class ReadingLogService(
         )
     }
 }
+
+data class CreateLogResult(
+    val log: ReadingLog,
+    val finishedCount: Int?
+)

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/ReadingLogRepository.kt
@@ -151,4 +151,13 @@ interface ReadingLogRepository : JpaRepository<ReadingLog, Long> {
         @Param("userId") userId: Long,
         @Param("bookId") bookId: Long
     ): List<ReadingLog>
+
+    /**
+     * 특정 책의 완독 횟수 조회
+     */
+    fun countByUserIdAndBookIdAndBookStatus(
+        userId:Long,
+        bookId:Long,
+        bookStatus:ReadingLogStatus
+    ):Int
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
@@ -48,11 +48,4 @@ interface UserBookRepository : JpaRepository<UserBook, Long> {
         AND ub.status IN ('READING', 'FINISHED')
     """)
     fun findReadingAndFinishedBooksByUserId(@Param("userId") userId: Long): List<UserBook>
-    /**
-     * 완독 횟수 카운트용 쿼리
-     */
-    @Query("SELECT COUNT(ub) FROM UserBook ub WHERE ub.userId=:userId AND ub.status='FINISHED'")
-    fun countFinishedBookByUserId(@Param("userId") userId:Long): Int
-
-
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
@@ -48,4 +48,11 @@ interface UserBookRepository : JpaRepository<UserBook, Long> {
         AND ub.status IN ('READING', 'FINISHED')
     """)
     fun findReadingAndFinishedBooksByUserId(@Param("userId") userId: Long): List<UserBook>
+    /**
+     * 완독 횟수 카운트용 쿼리
+     */
+    @Query("SELECT COUNT(ub) FROM UserBook ub WHERE ub.userId=:userId AND ub.status='FINISHED'")
+    fun countFinishedBookByUserId(@Param("userId") userId:Long): Int
+
+
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/ReadingController.kt
@@ -154,7 +154,7 @@ class ReadingController(
         @Parameter(hidden = true) @LoginUserId userId: Long,
         @Valid @RequestBody request: CreateReadingLogRequest
     ): ResponseEntity<ApiResponse<CreateReadingLogResponse>> {
-        val log = readingLogService.createLog(
+        val result = readingLogService.createLog(
             userId = userId,
             bookId = bookId,
             bookStatus = request.bookStatus,
@@ -163,8 +163,9 @@ class ReadingController(
             durationSeconds = request.durationSeconds,
             rating = request.rating
         )
+
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ApiResponse.created(CreateReadingLogResponse(log.id)))
+            .body(ApiResponse.created(CreateReadingLogResponse(result.log.id, result.finishedCount)))
     }
 
     @Operation(

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/CreateReadingLogResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/presentation/dto/CreateReadingLogResponse.kt
@@ -1,5 +1,6 @@
 package com.stepbookstep.server.domain.reading.presentation.dto
 
 data class CreateReadingLogResponse(
-    val recordId: Long
+    val recordId: Long,
+    val finishedCount: Int?=null
 )


### PR DESCRIPTION
## 📌 작업한 내용
독서 기록을 FINISHED로 기록할 경우 n번째 완독하셨습니다 문구를 띄워주기 위해 독서 기록 생성 응답으로 finishedCount를 추가하였습니다. 
FINISHED 기록에서는 해당 책의 누적 완독 횟수를 반환하고 READING과 STOPPED에서는 null을 반환합니다.


## 🔍 참고 사항
createLog() 반환 타입을 ReadingLog에서 CreateLogResult로 변경하였습니다. finishedCount는 ReadingLog 엔티티에 속하지 않는 값이라 ReadingLog와 finishedCount를 함께 담는 CreateLogResult를 도입하였습니다.



## 🖼️ 스크린샷
<img width="1262" height="488" alt="image" src="https://github.com/user-attachments/assets/13071508-48df-43c6-8b9d-4a1fc315a10f" />


## 🔗 관련 이슈
closed #78 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인