### PR TITLE
[feat] 카카오 재로그인 시 상태 변경 로직 수정

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/MyProfileService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/mypage/application/MyProfileService.kt
@@ -7,6 +7,7 @@ import com.stepbookstep.server.domain.user.domain.UserCategoryPreferenceReposito
 import com.stepbookstep.server.domain.user.domain.UserGenrePreference
 import com.stepbookstep.server.domain.user.domain.UserGenrePreferenceRepository
 import com.stepbookstep.server.domain.user.domain.UserRepository
+import com.stepbookstep.server.domain.user.domain.UserStatus
 import com.stepbookstep.server.external.kakao.KakaoUnlinkClient
 import com.stepbookstep.server.global.response.CustomException
 import com.stepbookstep.server.global.response.ErrorCode
@@ -132,7 +133,7 @@ class MyProfileService(
 
         refreshTokenRepository.deleteByUserId(userId)
 
-        user.status = "WITHDRAWN"
+        user.status = UserStatus.WITHDRAWN
         user.updatedAt = OffsetDateTime.now()
     }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
@@ -2,8 +2,10 @@ package com.stepbookstep.server.domain.user.application
 
 import com.stepbookstep.server.domain.user.domain.User
 import com.stepbookstep.server.domain.user.domain.UserRepository
+import com.stepbookstep.server.domain.user.domain.UserStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
 
 /**
  * 사용자 관련 비즈니스 로직을 처리하는 서비스 클래스
@@ -39,19 +41,31 @@ class UserService(
      */
     @Transactional
     fun getOrCreateKakaoUser(providerUserId: String, nickname: String, email: String): Pair<User, Boolean> {
-        val existingUser = userRepository.findByProviderAndProviderUserId("KAKAO", providerUserId)
+        val user = userRepository.findByProviderAndProviderUserId("KAKAO", providerUserId)
 
-        return if (existingUser != null) {
-            existingUser to false
-        } else {
-            val newUser = User(
-                provider = "KAKAO",
-                providerUserId = providerUserId,
-                nickname = nickname,
-                email = email
-            )
-            userRepository.save(newUser) to true
+        if (user != null) {
+
+            // 탈퇴 유저 복구
+            if (user.status == UserStatus.WITHDRAWN) {
+                user.status = UserStatus.ACTIVE
+                user.updatedAt = OffsetDateTime.now()
+
+                return user to true // 다시 가입 처리
+            }
+
+            return user to false
         }
+
+        // 신규 가입
+        val newUser = User(
+            provider = "KAKAO",
+            providerUserId = providerUserId,
+            nickname = nickname,
+            email = email,
+            status = UserStatus.ACTIVE
+        )
+
+        return userRepository.save(newUser) to true
     }
 }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
@@ -53,7 +53,7 @@ class UserService(
                 user.email = email
                 user.updatedAt = OffsetDateTime.now()
 
-                return user to true // 다시 가입 처리
+                return user to false // 다시 가입 처리
             }
 
             return user to false

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
@@ -48,6 +48,9 @@ class UserService(
             // 탈퇴 유저 복구
             if (user.status == UserStatus.WITHDRAWN) {
                 user.status = UserStatus.ACTIVE
+
+                user.nickname = nickname
+                user.email = email
                 user.updatedAt = OffsetDateTime.now()
 
                 return user to true // 다시 가입 처리

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/User.kt
@@ -28,8 +28,9 @@ class User(
     @Column(nullable = false)
     var nickname: String,
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    var status: String = "ACTIVE",
+    var status: UserStatus = UserStatus.ACTIVE,
 
     @Column(nullable = false)
     var email: String,

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserStatus.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/UserStatus.kt
@@ -1,0 +1,12 @@
+package com.stepbookstep.server.domain.user.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사용자 상태")
+enum class UserStatus {
+    @Schema(description = "정상 이용 중인 사용자")
+    ACTIVE,
+
+    @Schema(description = "탈퇴 처리된 사용자 (소프트 탈퇴)")
+    WITHDRAWN
+}


### PR DESCRIPTION
## 📌 작업한 내용
카카오 최초 로그인 -> 탈퇴 -> 재가입시 상태 변경이 안되는 오류가 발생하여 로직을 수정합니다.

최초 로그인 → 신규 회원 생성 (ACTIVE) -> 탈퇴 회원 (WITHDRAWN)
기존 WITHDRAWN 회원 로그인 → 상태 복구(ACTIVE) 후 로그인

## 🔍 참고 사항


## 🖼️ 스크린샷
<img width="116" height="321" alt="스크린샷 2026-02-09 오후 8 51 51" src="https://github.com/user-attachments/assets/5e7d2338-a58d-4d6b-b24f-fbe3b72e27ad" />


## 🔗 관련 이슈
#82 

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인