### PR TITLE
[feat] 완독 횟수를 FINISHED 상태인 책의 권수 반환으로 변경

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -112,7 +112,7 @@ class ReadingLogService(
         }
 
         val finishedCount: Int? = if (bookStatus == FINISHED) {
-            readingLogRepository.countByUserIdAndBookIdAndBookStatus(userId, bookId, FINISHED)
+            userBookRepository.countByUserIdAndStatus(userId, ReadStatus.FINISHED)
         } else null
 
         return CreateLogResult(log, finishedCount)

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/domain/UserBookRepository.kt
@@ -1,5 +1,6 @@
 package com.stepbookstep.server.domain.reading.domain
 
+import com.stepbookstep.server.domain.mypage.domain.ReadStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -48,4 +49,7 @@ interface UserBookRepository : JpaRepository<UserBook, Long> {
         AND ub.status IN ('READING', 'FINISHED')
     """)
     fun findReadingAndFinishedBooksByUserId(@Param("userId") userId: Long): List<UserBook>
+
+
+    fun countByUserIdAndStatus(userId: Long, status: ReadStatus):Int
 }


### PR DESCRIPTION
## 📌 작업한 내용
전에 반복해서 완독할 수 있다고 하셨어서 완독 횟수가 특정 책에 대한 완독 횟수일 것이라고 생각하고 구현해두었는데, 알고보니 모든 책에 대한 사용자의 완독 횟수를 반환하는 컴포넌트였습니다! 따라서 사용자의 FINISHED 상태의 책 권수를 반환해주는 로직으로 수정하였습니다... 


## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인