### PR TITLE
[feat] 카카오 로그인 응답에 가입 상태 추가

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/AuthService.kt
@@ -44,7 +44,7 @@ class AuthService(
             ?: throw CustomException(ErrorCode.EMAIL_REQUIRED)
 
         // 2) 유저 조회/생성 (DB Transaction - UserService 내부에서 처리)
-        val (user, isNewUser) =
+        val (user, signupType) =
             userService.getOrCreateKakaoUser(
                 providerUserId = providerUserId,
                 nickname = nicknameFromKakao,
@@ -61,7 +61,7 @@ class AuthService(
         return KakaoLoginResponse(
             accessToken = accessToken,
             refreshToken = refreshToken,
-            isNewUser = isNewUser,
+            signupType = signupType,
             nickname = user.nickname,
             email = user.email
         )
@@ -87,7 +87,7 @@ class AuthService(
         val email = kakaoMe.email
             ?: throw CustomException(ErrorCode.EMAIL_REQUIRED)
 
-        val (user, isNewUser) =
+        val (user, signupType) =
             userService.getOrCreateKakaoUser(
                 providerUserId = providerUserId,
                 nickname = nicknameFromKakao,
@@ -102,7 +102,7 @@ class AuthService(
         return KakaoLoginResponse(
             accessToken = accessToken,
             refreshToken = refreshToken,
-            isNewUser = isNewUser,
+            signupType = signupType,
             nickname = user.nickname,
             email = user.email
         )

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoLoginResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoLoginResponse.kt
@@ -1,9 +1,11 @@
 package com.stepbookstep.server.domain.auth.application.dto
 
+import com.stepbookstep.server.domain.user.domain.SignupType
+
 data class KakaoLoginResponse(
     val accessToken: String,
     val refreshToken: String,
-    val isNewUser: Boolean,
+    val signupType: SignupType,
     val nickname: String?,
     val email: String?
 )

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/application/UserService.kt
@@ -1,5 +1,6 @@
 package com.stepbookstep.server.domain.user.application
 
+import com.stepbookstep.server.domain.user.domain.SignupType
 import com.stepbookstep.server.domain.user.domain.User
 import com.stepbookstep.server.domain.user.domain.UserRepository
 import com.stepbookstep.server.domain.user.domain.UserStatus
@@ -40,7 +41,7 @@ class UserService(
      * @return Pair(유저 객체, 신규 가입 여부)
      */
     @Transactional
-    fun getOrCreateKakaoUser(providerUserId: String, nickname: String, email: String): Pair<User, Boolean> {
+    fun getOrCreateKakaoUser(providerUserId: String, nickname: String, email: String): Pair<User, SignupType> {
         val user = userRepository.findByProviderAndProviderUserId("KAKAO", providerUserId)
 
         if (user != null) {
@@ -53,10 +54,10 @@ class UserService(
                 user.email = email
                 user.updatedAt = OffsetDateTime.now()
 
-                return user to false // 다시 가입 처리
+                return user to SignupType.REJOIN // 다시 가입 처리
             }
 
-            return user to false
+            return user to SignupType.EXISTING
         }
 
         // 신규 가입
@@ -68,7 +69,7 @@ class UserService(
             status = UserStatus.ACTIVE
         )
 
-        return userRepository.save(newUser) to true
+        return userRepository.save(newUser) to SignupType.NEW
     }
 }
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/user/domain/SignupType.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/user/domain/SignupType.kt
@@ -1,0 +1,7 @@
+package com.stepbookstep.server.domain.user.domain
+
+enum class SignupType {
+    NEW,          // 완전 신규
+    REJOIN,       // 탈퇴 후 재가입
+    EXISTING      // 기존 유저
+}


### PR DESCRIPTION
## 📌 작업한 내용
탈퇴 후 카카오 재로그인 시 기존 유저로 인식되어 온보딩을 건너뛰고 홈으로 이동하는 문제가 있었습니다. 
이를 위해 기존 새로운 유저만을 판단하던 응답 `isNewUser` 대신 카카오 로그인 시 유저 상태를 명확히 구분하기 위해 `SignupType` 응답을 추가합니다.

## SignupType 분기 기준

| SignupType | 발생 시점 | DB 상태 | 설명 |
|-----------|----------|--------|------|
| NEW | 최초 카카오 로그인 | 유저 없음 | 신규 회원 가입 |
| REJOIN | 탈퇴 후 다시 카카오 로그인 | WITHDRAWN → ACTIVE | 탈퇴 계정 복구(재가입) |
| EXISTING | 이미 가입된 상태에서 로그인 | ACTIVE | 기존 회원 로그인 |


## 🔍 참고 사항


## 🖼️ 스크린샷
1. 신규 회원 가입
<img width="1429" height="555" alt="스크린샷 2026-02-10 오전 1 21 14" src="https://github.com/user-attachments/assets/d821c254-2123-4c8b-972c-da7e85b0183a" />

2. 탈퇴 후 다시 카카오 로그인
<img width="1411" height="532" alt="스크린샷 2026-02-10 오전 1 23 09" src="https://github.com/user-attachments/assets/6458b827-de39-497b-a06f-75a8f5f86cfd" />

3. 이미 가입된 상태에서 로그인
<img width="1411" height="540" alt="스크린샷 2026-02-10 오전 1 24 55" src="https://github.com/user-attachments/assets/7cf6bc5f-b57e-48f0-b3bb-1f87738a29c3" />



## 🔗 관련 이슈
#86 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인