### PR TITLE
[refactor] 전체 도서 조회 로직 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
 
     // Kotlin
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // Jackson Java 8 Date/Time
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/Book.kt
@@ -1,5 +1,6 @@
 package com.stepbookstep.server.domain.book.domain
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.persistence.*
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -82,6 +83,7 @@ class Book(
     val vocabLevel: VocabLevel = VocabLevel.EASY,
 
     @Column(name = "is_bestseller", nullable = false)
+    @param:JsonProperty("isBestseller")
     val isBestseller: Boolean = false,
 
     // ===== 시스템 필드 =====

--- a/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/book/domain/BookRepository.kt
@@ -1,7 +1,5 @@
 package com.stepbookstep.server.domain.book.domain
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
@@ -41,4 +39,10 @@ interface BookRepository : JpaRepository<Book, Long>, JpaSpecificationExecutor<B
 
     @Query("SELECT b FROM Book b WHERE b.genreId = :genreId")
     fun findAllByGenreId(@Param("genreId") genreId: Long): List<Book>
+
+    @Query("SELECT DISTINCT b.categoryId FROM Book b")
+    fun findDistinctCategoryIds(): List<Long>
+
+    @Query("SELECT DISTINCT b.genreId FROM Book b WHERE b.genreId IS NOT NULL")
+    fun findDistinctGenreIds(): List<Long>
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeCacheService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeCacheService.kt
@@ -41,4 +41,14 @@ class HomeCacheService(
     fun getBooksByGenreId(genreId: Long): List<Book> {
         return bookRepository.findAllByGenreId(genreId)
     }
+
+    @Cacheable(value = ["distinctCategoryIds"])
+    fun getDistinctCategoryIds(): List<Long> {
+        return bookRepository.findDistinctCategoryIds()
+    }
+
+    @Cacheable(value = ["distinctGenreIds"])
+    fun getDistinctGenreIds(): List<Long> {
+        return bookRepository.findDistinctGenreIds()
+    }
 }

--- a/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/home/application/HomeQueryService.kt
@@ -101,12 +101,9 @@ class HomeQueryService(
     }
 
     private fun selectRandomCategoryOrGenre(): SelectedBooks {
-        val allBooks = bookRepository.findAll()
-
-        // categoryId가 있는 책들의 고유 categoryId 목록
-        val categoryIds = allBooks.mapNotNull { it.categoryId }.distinct()
-        // genreId가 있는 책들의 고유 genreId 목록
-        val genreIds = allBooks.mapNotNull { it.genreId }.distinct()
+        // 캐시된 DISTINCT ID 목록 조회
+        val categoryIds = homeCacheService.getDistinctCategoryIds()
+        val genreIds = homeCacheService.getDistinctGenreIds()
 
         val allOptions = mutableListOf<Pair<String, Long>>()
         categoryIds.forEach { allOptions.add("category" to it) }
@@ -118,8 +115,8 @@ class HomeQueryService(
 
         val selected = allOptions.random()
         val books = when (selected.first) {
-            "category" -> allBooks.filter { it.categoryId == selected.second }
-            "genre" -> allBooks.filter { it.genreId == selected.second }
+            "category" -> homeCacheService.getBooksByCategoryId(selected.second)
+            "genre" -> homeCacheService.getBooksByGenreId(selected.second)
             else -> emptyList()
         }.shuffled().take(20)
 

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingGoalService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingGoalService.kt
@@ -12,6 +12,7 @@ import com.stepbookstep.server.domain.reading.domain.UserBook
 import com.stepbookstep.server.domain.reading.domain.UserBookRepository
 import com.stepbookstep.server.global.response.CustomException
 import com.stepbookstep.server.global.response.ErrorCode
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -30,6 +31,7 @@ class ReadingGoalService(
      * - 기존 활성 목표가 없으면 새로 생성
      * - 기존 활성 목표가 있으면 수정
      */
+    @CacheEvict(value = ["userStatistics"], key = "#userId + '_' + T(java.time.Year).now().value")
     @Transactional
     fun upsertGoal(
         userId: Long,
@@ -96,6 +98,7 @@ class ReadingGoalService(
     /**
      * 활성 목표 삭제 (비활성화)
      */
+    @CacheEvict(value = ["userStatistics"], key = "#userId + '_' + T(java.time.Year).now().value")
     @Transactional
     fun deleteGoal(userId: Long, bookId: Long) {
         val existingGoal = readingGoalRepository.findByUserIdAndBookIdAndActiveTrue(userId, bookId)

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/ReadingLogService.kt
@@ -15,6 +15,7 @@ import com.stepbookstep.server.domain.reading.presentation.dto.GoalInfo
 import com.stepbookstep.server.domain.reading.presentation.dto.ReadingLogItem
 import com.stepbookstep.server.global.response.CustomException
 import com.stepbookstep.server.global.response.ErrorCode
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -28,6 +29,7 @@ class ReadingLogService(
     private val readingGoalRepository: ReadingGoalRepository
 ) {
 
+    @CacheEvict(value = ["userStatistics"], key = "#userId + '_' + T(java.time.Year).now().value")
     @Transactional
     fun createLog(
         userId: Long,

--- a/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/reading/application/StatisticService.kt
@@ -3,6 +3,7 @@ package com.stepbookstep.server.domain.reading.application
 import com.stepbookstep.server.domain.book.domain.BookRepository
 import com.stepbookstep.server.domain.reading.domain.*
 import com.stepbookstep.server.domain.reading.presentation.dto.*
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -21,6 +22,7 @@ class StatisticsService(
     /**
      * 전체 독서 통계 조회
      */
+    @Cacheable(value = ["userStatistics"], key = "#userId + '_' + #year")
     @Transactional(readOnly = true)
     fun getReadingStatistics(userId: Long, year: Int): ReadingStatisticsResponse {
         return ReadingStatisticsResponse(

--- a/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
@@ -1,10 +1,7 @@
 package com.stepbookstep.server.global.config
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
@@ -13,9 +10,8 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.serializer.RedisSerializer
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
-import org.springframework.data.redis.serializer.SerializationException
 import org.springframework.data.redis.serializer.StringRedisSerializer
 import java.time.Duration
 
@@ -25,40 +21,9 @@ class RedisCacheConfig {
 
     @Bean
     fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
-        val objectMapper = ObjectMapper()
-        objectMapper.registerModule(JavaTimeModule())
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        objectMapper.activateDefaultTyping(
-            BasicPolymorphicTypeValidator.builder()
-                .allowIfBaseType(Any::class.java)
-                .build(),
-            ObjectMapper.DefaultTyping.NON_FINAL,
-            JsonTypeInfo.As.PROPERTY
-        )
-
-        val serializer = object : RedisSerializer<Any> {
-            override fun serialize(t: Any?): ByteArray {
-                if (t == null) {
-                    return ByteArray(0)
-                }
-                try {
-                    return objectMapper.writeValueAsBytes(t)
-                } catch (e: Exception) {
-                    throw SerializationException("Could not write JSON: " + e.message, e)
-                }
-            }
-
-            override fun deserialize(bytes: ByteArray?): Any? {
-                if (bytes == null || bytes.isEmpty()) {
-                    return null
-                }
-                try {
-                    return objectMapper.readValue(bytes, Any::class.java)
-                } catch (e: Exception) {
-                    throw SerializationException("Could not read JSON: " + e.message, e)
-                }
-            }
+        val objectMapper = ObjectMapper().apply {
+            registerModule(JavaTimeModule())
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         }
 
         val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
@@ -67,14 +32,19 @@ class RedisCacheConfig {
                 RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
             )
             .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(serializer)
+                RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer(objectMapper))
             )
 
         val cacheConfigurations = mapOf(
             "genreBooks" to defaultConfig.entryTtl(Duration.ofHours(6)),
             "bestsellerBooks" to defaultConfig.entryTtl(Duration.ofHours(12)),
             "bookDetail" to defaultConfig.entryTtl(Duration.ofHours(24)),
-            "booksByLevel" to defaultConfig.entryTtl(Duration.ofHours(1))
+            "booksByLevel" to defaultConfig.entryTtl(Duration.ofHours(1)),
+            "userStatistics" to defaultConfig.entryTtl(Duration.ofMinutes(30)),
+            "distinctCategoryIds" to defaultConfig.entryTtl(Duration.ofHours(24)),
+            "distinctGenreIds" to defaultConfig.entryTtl(Duration.ofHours(24)),
+            "categoryBooks" to defaultConfig.entryTtl(Duration.ofHours(6)),
+            "genreIdBooks" to defaultConfig.entryTtl(Duration.ofHours(6))
         )
 
         return RedisCacheManager.builder(redisConnectionFactory)

--- a/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/stepbookstep/server/global/config/RedisCacheConfig.kt
@@ -1,8 +1,12 @@
 package com.stepbookstep.server.global.config
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -21,9 +25,15 @@ class RedisCacheConfig {
 
     @Bean
     fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
-        val objectMapper = ObjectMapper().apply {
+        val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
             registerModule(JavaTimeModule())
             disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+            )
         }
 
         val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
기존 로직은 전체 도서 테이블을 메모리에 로딩한 뒤 애플리케이션 레벨에서 가공하고 있었습니다.  
이로 인해 실제로는 고유한 `categoryId`, `genreId` 몇 개만 필요함에도 불구하고  
도서가 10,000권이면 10,000개의 `Book` 객체가 모두 메모리에 로딩되는 구조였습니다.

이를 개선하기 위해 **DB 레벨에서 DISTINCT 쿼리를 수행하도록 리팩토링**했습니다.

- 도서 수와 무관하게 실제 필요한 ID 개수만 반환
- 메모리 사용량 감소
- 불필요한 객체 생성 제거

### 캐시 구성
| 캐시명              | 용도                         | TTL    |
|-------------------|------------------------------|--------|
| distinctCategoryIds | 고유 카테고리 ID 목록          | 24시간 |
| distinctGenreIds   | 고유 장르 ID 목록              | 24시간 |
| categoryBooks      | 특정 카테고리의 도서 목록       | 6시간  |
| genreIdBooks       | 특정 장르의 도서 목록           | 6시간  |
| userStatistics     | 사용자 통계                   | 30분   |

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
### JMeter 테스트 중 Redis 캐시 직렬화 이슈 해결

JMeter 부하 테스트 과정에서 Redis 캐시 역직렬화 오류가 발생했습니다.  
원인은 **직렬화 설정 변경 과정에서 기존 캐시 데이터와 새로운 직렬화 형식이 호환되지 않았고**,  
**타입 정보 누락, Boolean 필드명 규칙, Java Time 타입 미지원** 등이 복합적으로 작용한 것으로 보입니다,,🥺

이를 해결하기 위해 다음과 같이 조치했습니다.

- `activateDefaultTyping` 적용으로 `@class` 기반 타입 정보 저장
- `jacksonObjectMapper()` 사용으로 Kotlin 클래스 안정적 지원
- `JavaTimeModule` 등록으로 `LocalDate`, `LocalDateTime` 직렬화 지원
- `@JsonProperty` 적용으로 Boolean 필드명 불일치 문제 해결
- 직렬화 설정 변경 후 **Redis 캐시 초기화(FLUSHALL)** 수행

해당 수정 이후 JMeter 테스트 환경에서 Redis 캐시를 정상적으로 저장·조회함을 확인했습니다!

### JMeter Thread Group 설정
동시 사용자 수 100명이 10초에 걸쳐 진입하고, 1분간 무한 반복하는 테스트를 유지하도록 설정했습니다.


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

### 캐싱 전
<img width="1175" height="695" alt="image" src="https://github.com/user-attachments/assets/c4778757-1559-4432-9800-d2498b86b78d" />

### 캐싱 후
<img width="1173" height="727" alt="image" src="https://github.com/user-attachments/assets/491b3e7d-95d1-468f-b6f2-597ad031e98e" />


캐싱 적용 전에는 최대 응답 시간이 약 72ms까지 상승하며, 부하 증가 시 DB 영향으로 인해 응답 시간이 급격히 증가하는 구간이 확인되었습니다. 반면 캐싱 적용 후에는 최대 응답 시간이 약 59ms로 감소하고 변동 폭도 줄어들어, 부하 상황에서도 보다 안정적으로 수렴하는 패턴을 보였습니다.

다만 그래프의 차이가 생각보다 크지 않은 것을 확인할 수 있는데,, 기존 시스템의 기본 성능이 이미 양호했기 때문에 평균 응답 시간의 큰 차이는 나타나지 않았다고 보이며, 캐싱은 평균 속도 개선보다는 최대 지연 시간 감소와 안정성 향상 측면에서 의미 있는 효과를 보였습니다. 
향후 트래픽이 증가할 경우 고부하 환경에서 그 효과가 더욱 뚜렷해질 것으로 예측됩니다!!

### 리뷰어분들께,,,💖 
더 정확한 테스트를 할 수 있는 테스트 환경을 추천해주시면 감사하겠습니다!ㅜ.ㅜ 🫠

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#60 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인