### PR TITLE
[fix] 로그인 응답에 userId 추가

### DIFF
--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/AuthService.kt
@@ -59,6 +59,7 @@ class AuthService(
         refreshTokenService.save(userId = user.id, refreshToken = refreshToken)
 
         return KakaoLoginResponse(
+            userId=user.id,
             accessToken = accessToken,
             refreshToken = refreshToken,
             signupType = signupType,
@@ -100,6 +101,7 @@ class AuthService(
         refreshTokenService.save(userId = user.id, refreshToken = refreshToken)
 
         return KakaoLoginResponse(
+            userId=user.id,
             accessToken = accessToken,
             refreshToken = refreshToken,
             signupType = signupType,

--- a/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoLoginResponse.kt
+++ b/src/main/kotlin/com/stepbookstep/server/domain/auth/application/dto/KakaoLoginResponse.kt
@@ -3,6 +3,7 @@ package com.stepbookstep.server.domain.auth.application.dto
 import com.stepbookstep.server.domain.user.domain.SignupType
 
 data class KakaoLoginResponse(
+    val userId: Long,
     val accessToken: String,
     val refreshToken: String,
     val signupType: SignupType,


### PR DESCRIPTION
## 📌 작업한 내용
프론트 측에서 로그인 응답에 userId가 주어지지 않아서 일부 API에 오류가 발생한다고 하셔서 로그인 API 응답으로 userId를 반환하도록 수정했습니다. 


## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인